### PR TITLE
docs: añadir specs retroactivas L2 para bloques 0-2 de Fase 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,28 @@ El desarrollo sigue un pipeline multi-agente (local + remoto). Detalle completo 
 
 **Labels del sistema**: `ai-analyze`, `ai-generate-pr`, `ai-generated`, `ai-reviewed`, `priority:p0/p1/p2`, `type:feature/bug/refactor/docs`, `phase:1/2/3`
 
+### Metodología por Fase
+
+**Fase 2 (Frontend):**
+- Pipeline completo: L1 (UX) → L2 (Técnico) → L3 (Issues) → L4 (Implementación)
+- Specs L1/L2/L3 generadas **antes** de implementar
+- 22 archivos de specs en `docs/specs/`
+
+**Fase 3 (Backend) — Bloques 0-2:**
+- Implementación directa desde plan general (`phase3-backend-plan.md`)
+- Specs L2 (diseño técnico) generadas **retroactivamente** tras commits:
+  - `L2-backend-00-infrastructure.md` (Bloque 0: infraestructura base)
+  - `L2-backend-01-profile.md` (Bloque 1: endpoints GET/PATCH perfil)
+  - `L2-backend-02-activities.md` (Bloque 2: CRUD actividades)
+- **Rationale**: Contratos API claros en PRD, schemas Zod compartidos, iteración rápida
+
+**Fase 3 (Backend) — Bloque 3+:**
+- Pipeline completo: L1 → L2 → L3 → L4 → L5 (QA/Tester)
+- Specs generadas **antes** de implementar
+- **Rationale**: Lógica IA compleja, prompts a diseñar, parseo archivos, mayor beneficio de diseño previo
+
+**Conclusión**: Metodología híbrida — aplicar pipeline completo donde aporta más valor (features complejas), permitir implementación directa para CRUD predecible.
+
 ---
 
 ## Notas para Claude Code

--- a/docs/specs/L2-backend-00-infrastructure.md
+++ b/docs/specs/L2-backend-00-infrastructure.md
@@ -1,0 +1,474 @@
+# L2 — Diseño Técnico: Infraestructura Base del Backend (Bloque 0)
+
+> **Tipo**: Especificación técnica (L2)
+> **Fase**: 3 — Backend + IA
+> **Bloque**: 0 — Infraestructura
+> **Estado**: ✅ Implementado (retroactivo)
+> **Fecha**: 2026-02-15
+> **Commit**: `a721d43`
+
+---
+
+## 1. Objetivo
+
+Establecer la infraestructura base del backend Fastify para soportar:
+- Configuración y validación de variables de entorno
+- Autenticación JWT con Supabase
+- Manejo centralizado de errores
+- CORS para el frontend Next.js
+- Clientes de Supabase (service role) y Anthropic (Claude API)
+- Estructura testeable (factory pattern)
+
+---
+
+## 2. Arquitectura
+
+### 2.1 Separación Entry Point vs Factory
+
+**Problema**: `index.ts` monolítico dificulta testing y reutilización.
+
+**Solución**: Factory pattern
+```
+apps/api/src/
+├── index.ts           # Entry point (start server, puerto 3001)
+└── app.ts             # Factory (build app, export para tests)
+```
+
+**app.ts** exporta función `buildApp()`:
+```typescript
+export async function buildApp(opts?: FastifyServerOptions) {
+  const fastify = Fastify(opts);
+
+  // Registrar plugins globales
+  await fastify.register(cors);
+  await fastify.register(errorHandler);
+
+  // Health check público
+  await fastify.register(healthRoutes);
+
+  // Rutas protegidas bajo /api/v1
+  await fastify.register(async (app) => {
+    app.addHook('onRequest', app.authenticate);
+    // Aquí van profileRoutes, activityRoutes, etc.
+  }, { prefix: '/api/v1' });
+
+  return fastify;
+}
+```
+
+**index.ts** consume `buildApp()`:
+```typescript
+const app = await buildApp({ logger: true });
+await app.listen({ port: config.port, host: '0.0.0.0' });
+```
+
+**Ventaja**: Tests pueden importar `buildApp()` sin levantar servidor.
+
+---
+
+### 2.2 Validación de Variables de Entorno
+
+**Archivo**: `apps/api/src/config/env.ts`
+
+**Schema Zod**:
+```typescript
+const envSchema = z.object({
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  ANTHROPIC_API_KEY: z.string().min(1),
+  PORT: z.coerce.number().default(3001),
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+});
+
+export const config = envSchema.parse(process.env);
+```
+
+**Comportamiento**:
+- ❌ Falla en startup si falta variable requerida
+- ✅ Type-safe: `config.SUPABASE_URL` es `string`, `config.PORT` es `number`
+- ✅ Defaults: `PORT=3001`, `NODE_ENV=development`
+
+---
+
+### 2.3 Plugin: CORS
+
+**Archivo**: `apps/api/src/plugins/cors.ts`
+
+**Propósito**: Permitir requests desde frontend Next.js (puerto 3000).
+
+**Configuración**:
+```typescript
+export default fp(async (fastify) => {
+  await fastify.register(fastifyCors, {
+    origin: process.env.NODE_ENV === 'production'
+      ? ['https://cycling-companion-web.vercel.app']
+      : ['http://localhost:3000'],
+    credentials: true,
+  });
+});
+```
+
+**Wrapped con `fastify-plugin`** para aplicar a nivel global (parent scope).
+
+---
+
+### 2.4 Plugin: Autenticación JWT Supabase
+
+**Archivo**: `apps/api/src/plugins/auth.ts`
+
+**Flujo**:
+1. Frontend envía `Authorization: Bearer <jwt_token>`
+2. Plugin extrae token del header
+3. Verifica token con Supabase (cliente con service_role_key)
+4. Decora `request.user` con datos del usuario autenticado
+
+**Implementación**:
+```typescript
+fastify.decorate('authenticate', async (request, reply) => {
+  const authHeader = request.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw new AppError('Missing or invalid authorization header', 401, 'UNAUTHORIZED');
+  }
+
+  const token = authHeader.substring(7);
+  const { data: { user }, error } = await supabase.auth.getUser(token);
+
+  if (error || !user) {
+    throw new AppError('Invalid or expired token', 401, 'UNAUTHORIZED');
+  }
+
+  request.user = user; // Decora request
+});
+```
+
+**Decorador de tipos** (`types/fastify.d.ts`):
+```typescript
+declare module 'fastify' {
+  interface FastifyRequest {
+    user?: User;
+  }
+  interface FastifyInstance {
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  }
+}
+```
+
+**Uso en rutas**:
+```typescript
+fastify.register(async (app) => {
+  app.addHook('onRequest', app.authenticate); // Protege todas las rutas del scope
+  // ... rutas protegidas
+}, { prefix: '/api/v1' });
+```
+
+---
+
+### 2.5 Plugin: Error Handler Centralizado
+
+**Archivo**: `apps/api/src/plugins/error-handler.ts`
+
+**Propósito**: Unificar respuestas de error en formato JSON estructurado.
+
+**Tipos de error manejados**:
+1. **ZodError** → 400 Bad Request
+2. **AppError** (custom) → Status code configurado
+3. **FastifyError** con `statusCode` → Status code del error
+4. **Error genérico** → 500 Internal Server Error
+
+**Clase `AppError`**:
+```typescript
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number = 500,
+    public code: string = 'INTERNAL_ERROR',
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+```
+
+**Handler**:
+```typescript
+fastify.setErrorHandler((error, request, reply) => {
+  // 1. Zod validation
+  if (error instanceof ZodError) {
+    return reply.status(400).send({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: error.issues, // Solo en dev
+    });
+  }
+
+  // 2. AppError
+  if (error instanceof AppError) {
+    if (error.statusCode >= 500) request.log.error(error);
+    return reply.status(error.statusCode).send({
+      error: error.message,
+      code: error.code,
+    });
+  }
+
+  // 3. Fastify errors
+  if ('statusCode' in error) {
+    return reply.status(error.statusCode).send({
+      error: error.message,
+      code: getErrorCode(error.statusCode),
+    });
+  }
+
+  // 4. Generic 500
+  request.log.error(error);
+  return reply.status(500).send({
+    error: process.env.NODE_ENV === 'production'
+      ? 'Internal server error'
+      : error.message,
+    code: 'INTERNAL_ERROR',
+  });
+});
+```
+
+**Formato de respuesta de error**:
+```json
+{
+  "error": "User not found",
+  "code": "NOT_FOUND",
+  "details": { ... }  // Opcional, solo en dev
+}
+```
+
+---
+
+### 2.6 Servicios: Clientes de Terceros
+
+#### Supabase Client
+
+**Archivo**: `apps/api/src/services/supabase.ts`
+
+```typescript
+import { createClient } from '@supabase/supabase-js';
+import { config } from '../config/env';
+
+export const supabase = createClient(
+  config.SUPABASE_URL,
+  config.SUPABASE_SERVICE_ROLE_KEY, // Bypass RLS
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  }
+);
+```
+
+**Uso**: Operaciones server-side que necesitan bypassear RLS (con service_role_key).
+
+#### Anthropic Client
+
+**Archivo**: `apps/api/src/services/anthropic.ts`
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { config } from '../config/env';
+
+export const anthropic = new Anthropic({
+  apiKey: config.ANTHROPIC_API_KEY,
+});
+```
+
+**Uso**: Llamadas a Claude API para análisis IA y generación de planes.
+
+---
+
+### 2.7 Route: Health Check
+
+**Archivo**: `apps/api/src/routes/health.ts`
+
+**Endpoint**: `GET /health`
+
+**Propósito**: Verificar que el servidor está vivo (para Render health checks).
+
+```typescript
+export default async function healthRoutes(fastify: FastifyInstance) {
+  fastify.get('/health', async () => {
+    return { status: 'ok', timestamp: new Date().toISOString() };
+  });
+}
+```
+
+**Respuesta**:
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-02-15T10:25:00.000Z"
+}
+```
+
+**No requiere autenticación** (registrada fuera del scope protegido).
+
+---
+
+## 3. Dependencias Añadidas
+
+```json
+{
+  "dependencies": {
+    "@fastify/cors": "^10.0.1",
+    "@anthropic-ai/sdk": "^0.35.0",
+    "@fastify/multipart": "^9.1.0",
+    "fastify-plugin": "^5.0.1"
+  }
+}
+```
+
+- **@fastify/cors**: CORS middleware oficial de Fastify
+- **@anthropic-ai/sdk**: Cliente oficial de Anthropic para Claude API
+- **@fastify/multipart**: Para upload de archivos .fit/.gpx (preparación para Bloque 3)
+- **fastify-plugin**: Wrapper para plugins que deben aplicar a parent scope
+
+---
+
+## 4. Estructura de Archivos Resultante
+
+```
+apps/api/src/
+├── index.ts                      # ✨ Entry point (start server)
+├── app.ts                        # ✨ Factory (buildApp para tests)
+├── config/
+│   └── env.ts                    # ✨ Validación env vars con Zod
+├── plugins/
+│   ├── cors.ts                   # ✨ CORS para frontend
+│   ├── auth.ts                   # ✨ JWT Supabase (decorator authenticate)
+│   └── error-handler.ts          # ✨ Error handler centralizado
+├── routes/
+│   └── health.ts                 # ✨ GET /health (movida de index.ts)
+├── services/
+│   ├── supabase.ts               # ✨ Cliente Supabase (service_role)
+│   └── anthropic.ts              # ✨ Cliente Anthropic (Claude API)
+└── types/
+    └── fastify.d.ts              # ✨ Decoradores TypeScript
+```
+
+✨ = Nuevo en Bloque 0
+
+---
+
+## 5. Testing
+
+**Estrategia**:
+- Tests unitarios para `config/env.ts` (validación)
+- Tests de integración para plugins (auth, error-handler)
+- Tests E2E para rutas protegidas vs públicas
+
+**Ejemplo de test con factory**:
+```typescript
+import { buildApp } from '../src/app';
+
+describe('Auth Plugin', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should reject requests without token', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/profile',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: 'Missing or invalid authorization header',
+      code: 'UNAUTHORIZED',
+    });
+  });
+});
+```
+
+---
+
+## 6. Decisiones Técnicas (ADRs)
+
+### ADR-001: Factory Pattern para testabilidad
+
+**Contexto**: `index.ts` monolítico dificulta tests unitarios.
+
+**Decisión**: Separar `app.ts` (factory) de `index.ts` (entry point).
+
+**Consecuencias**:
+- ✅ Tests pueden importar `buildApp()` sin levantar servidor
+- ✅ Reutilizable para diferentes entornos (test, dev, prod)
+- ⚠️ Requiere disciplina: lógica en `app.ts`, no en `index.ts`
+
+### ADR-002: Service Role Key para operaciones backend
+
+**Contexto**: Backend necesita leer/escribir datos de cualquier usuario.
+
+**Decisión**: Usar `SUPABASE_SERVICE_ROLE_KEY` que bypasea RLS.
+
+**Consecuencias**:
+- ✅ Flexibilidad total en queries server-side
+- ⚠️ Seguridad: verificar auth en API layer (no confiar en RLS)
+- ⚠️ Nunca exponer service_role_key al frontend
+
+### ADR-003: Fastify-plugin para CORS y Error Handler
+
+**Contexto**: Plugins deben aplicar globalmente, no solo al scope que los registra.
+
+**Decisión**: Wrappear con `fastify-plugin`.
+
+**Consecuencias**:
+- ✅ CORS aplica a todas las rutas
+- ✅ Error handler maneja errores de cualquier ruta
+- ⚠️ No usar para plugins que deben ser scoped (como auth en /api/v1)
+
+---
+
+## 7. Criterios de Aceptación
+
+- [x] `app.ts` exporta `buildApp()` que retorna `FastifyInstance`
+- [x] `index.ts` levanta servidor en puerto 3001 usando `buildApp()`
+- [x] Variables de entorno validadas con Zod en startup
+- [x] CORS configurado para `http://localhost:3000` (dev) y Vercel (prod)
+- [x] Plugin `authenticate` decora `request.user` con datos del usuario
+- [x] Error handler retorna JSON estructurado para todos los tipos de error
+- [x] Cliente Supabase con `service_role_key` disponible en `services/supabase.ts`
+- [x] Cliente Anthropic disponible en `services/anthropic.ts`
+- [x] `GET /health` retorna `{ status: 'ok' }` sin autenticación
+- [x] Rutas bajo `/api/v1` protegidas con `authenticate` hook
+
+---
+
+## 8. Archivos Modificados/Creados
+
+**Nuevos**:
+- `apps/api/src/app.ts`
+- `apps/api/src/config/env.ts`
+- `apps/api/src/plugins/auth.ts`
+- `apps/api/src/plugins/cors.ts`
+- `apps/api/src/plugins/error-handler.ts`
+- `apps/api/src/routes/health.ts`
+- `apps/api/src/services/supabase.ts`
+- `apps/api/src/services/anthropic.ts`
+- `apps/api/src/types/fastify.d.ts`
+
+**Modificados**:
+- `apps/api/src/index.ts` (simplificado, ahora solo llama a `buildApp()`)
+- `apps/api/package.json` (dependencias añadidas)
+- `pnpm-lock.yaml`
+
+---
+
+## 9. Próximos Pasos (Bloque 1)
+
+Con la infraestructura lista, Bloque 1 puede implementar:
+- Endpoint `GET /api/v1/profile` (usar `supabase` client)
+- Endpoint `PATCH /api/v1/profile` (validar con schemas de `shared`)
+- Service `profile.service.ts` con lógica de negocio
+- Tests de integración para endpoints de perfil

--- a/docs/specs/L2-backend-01-profile.md
+++ b/docs/specs/L2-backend-01-profile.md
@@ -1,0 +1,516 @@
+# L2 — Diseño Técnico: Endpoints de Perfil (Bloque 1)
+
+> **Tipo**: Especificación técnica (L2)
+> **Fase**: 3 — Backend + IA
+> **Bloque**: 1 — Perfil (GET/PATCH)
+> **Estado**: ✅ Implementado (retroactivo)
+> **Fecha**: 2026-02-15
+> **Commit**: `b9da9a8`
+
+---
+
+## 1. Objetivo
+
+Implementar endpoints de perfil de usuario para:
+- Obtener datos del perfil actual (`GET /api/v1/profile`)
+- Actualizar datos del perfil (`PATCH /api/v1/profile`)
+
+Estos endpoints son consumidos por la pantalla `/profile` del frontend.
+
+---
+
+## 2. Contratos de API
+
+### 2.1 GET /api/v1/profile
+
+**Propósito**: Obtener el perfil del usuario autenticado.
+
+**Autenticación**: ✅ Requerida (JWT en header `Authorization`)
+
+**Request**:
+```http
+GET /api/v1/profile HTTP/1.1
+Host: localhost:3001
+Authorization: Bearer <jwt_token>
+```
+
+**Response 200 OK**:
+```json
+{
+  "id": "uuid-user-123",
+  "email": "usuario@example.com",
+  "name": "Juan Pérez",
+  "age": 45,
+  "weight": 75,
+  "ftp": 250,
+  "max_hr": 180,
+  "resting_hr": 55,
+  "goal": "performance",
+  "created_at": "2026-02-10T10:00:00.000Z",
+  "updated_at": "2026-02-15T12:30:00.000Z"
+}
+```
+
+**Response 401 Unauthorized**:
+```json
+{
+  "error": "Missing or invalid authorization header",
+  "code": "UNAUTHORIZED"
+}
+```
+
+**Response 404 Not Found**:
+```json
+{
+  "error": "User profile not found",
+  "code": "NOT_FOUND"
+}
+```
+
+---
+
+### 2.2 PATCH /api/v1/profile
+
+**Propósito**: Actualizar datos del perfil del usuario autenticado.
+
+**Autenticación**: ✅ Requerida
+
+**Request**:
+```http
+PATCH /api/v1/profile HTTP/1.1
+Host: localhost:3001
+Authorization: Bearer <jwt_token>
+Content-Type: application/json
+
+{
+  "name": "Juan Pérez Actualizado",
+  "weight": 74,
+  "ftp": 255,
+  "goal": "health"
+}
+```
+
+**Validación**: Body validado con `onboardingSchema.partial()` de `@cycling-companion/shared`.
+
+**Campos actualizables**:
+- `name` (string, min 1 char)
+- `age` (number, >= 18)
+- `weight` (number, > 0)
+- `ftp` (number, > 0)
+- `max_hr` (number, > 0)
+- `resting_hr` (number, > 0)
+- `goal` (enum: `performance`, `health`, `weight_loss`, `recovery`)
+
+**Response 200 OK**:
+```json
+{
+  "id": "uuid-user-123",
+  "email": "usuario@example.com",
+  "name": "Juan Pérez Actualizado",
+  "age": 45,
+  "weight": 74,
+  "ftp": 255,
+  "max_hr": 180,
+  "resting_hr": 55,
+  "goal": "health",
+  "created_at": "2026-02-10T10:00:00.000Z",
+  "updated_at": "2026-02-15T14:00:00.000Z"
+}
+```
+
+**Response 400 Bad Request** (validación Zod):
+```json
+{
+  "error": "Validation failed",
+  "code": "VALIDATION_ERROR",
+  "details": [
+    {
+      "code": "too_small",
+      "minimum": 0,
+      "path": ["ftp"],
+      "message": "Number must be greater than 0"
+    }
+  ]
+}
+```
+
+**Response 401 Unauthorized**:
+```json
+{
+  "error": "Missing or invalid authorization header",
+  "code": "UNAUTHORIZED"
+}
+```
+
+**Response 404 Not Found**:
+```json
+{
+  "error": "User profile not found",
+  "code": "NOT_FOUND"
+}
+```
+
+---
+
+## 3. Arquitectura
+
+### 3.1 Capa de Servicio
+
+**Archivo**: `apps/api/src/services/profile.service.ts`
+
+**Responsabilidad**: Lógica de negocio para operaciones de perfil.
+
+**Métodos**:
+
+#### `getProfile(userId: string)`
+
+```typescript
+export async function getProfile(userId: string) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('id', userId)
+    .single();
+
+  if (error || !data) {
+    throw new AppError('User profile not found', 404, 'NOT_FOUND');
+  }
+
+  return data;
+}
+```
+
+**Comportamiento**:
+- Query a tabla `users` filtrando por `id`
+- `.single()` garantiza un único resultado
+- Si no existe, lanza `AppError` con 404
+
+#### `updateProfile(userId: string, updates: Partial<OnboardingData>)`
+
+```typescript
+export async function updateProfile(
+  userId: string,
+  updates: Partial<OnboardingData>
+) {
+  // Validar con schema parcial
+  const validatedUpdates = onboardingSchema.partial().parse(updates);
+
+  const { data, error } = await supabase
+    .from('users')
+    .update(validatedUpdates)
+    .eq('id', userId)
+    .select()
+    .single();
+
+  if (error || !data) {
+    throw new AppError('Failed to update profile', 500, 'UPDATE_FAILED');
+  }
+
+  return data;
+}
+```
+
+**Comportamiento**:
+- Valida `updates` con `onboardingSchema.partial()` (permite campos opcionales)
+- Update solo de los campos enviados (PATCH semántico)
+- Retorna perfil actualizado con `.select().single()`
+
+---
+
+### 3.2 Capa de Rutas
+
+**Archivo**: `apps/api/src/routes/profile.ts`
+
+**Responsabilidad**: Definir endpoints HTTP y delegar a servicio.
+
+```typescript
+import type { FastifyInstance } from 'fastify';
+import { getProfile, updateProfile } from '../services/profile.service';
+
+export default async function profileRoutes(fastify: FastifyInstance) {
+  // GET /api/v1/profile
+  fastify.get('/profile', async (request) => {
+    const userId = request.user!.id;
+    return await getProfile(userId);
+  });
+
+  // PATCH /api/v1/profile
+  fastify.patch('/profile', async (request) => {
+    const userId = request.user!.id;
+    const updates = request.body as Partial<OnboardingData>;
+    return await updateProfile(userId, updates);
+  });
+}
+```
+
+**Notas**:
+- `request.user!.id`: Decorado por plugin `authenticate` (Bloque 0)
+- No requiere validación explícita de body (Zod en servicio lanza ZodError, capturado por error handler)
+- Rutas registradas en scope protegido (`/api/v1` con auth hook)
+
+---
+
+### 3.3 Integración en app.ts
+
+**Archivo**: `apps/api/src/app.ts`
+
+**Registro de rutas**:
+```typescript
+import profileRoutes from './routes/profile';
+
+export async function buildApp(opts?: FastifyServerOptions) {
+  const fastify = Fastify(opts);
+
+  // ... plugins globales
+
+  // Rutas protegidas
+  await fastify.register(async (app) => {
+    app.addHook('onRequest', app.authenticate);
+
+    // Registrar rutas de perfil
+    await app.register(profileRoutes);
+
+  }, { prefix: '/api/v1' });
+
+  return fastify;
+}
+```
+
+**Efecto**: Todas las rutas de `profileRoutes` quedan bajo `/api/v1/` y protegidas por auth.
+
+---
+
+## 4. Validación de Datos
+
+### Schema Zod Reutilizado
+
+**Origen**: `packages/shared/src/schemas/user-profile.ts`
+
+```typescript
+export const onboardingSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  age: z.number().int().min(18, 'Must be at least 18 years old'),
+  weight: z.number().positive('Weight must be positive'),
+  ftp: z.number().positive('FTP must be positive'),
+  max_hr: z.number().positive('Max HR must be positive'),
+  resting_hr: z.number().positive('Resting HR must be positive'),
+  goal: z.enum(['performance', 'health', 'weight_loss', 'recovery']),
+});
+
+export type OnboardingData = z.infer<typeof onboardingSchema>;
+```
+
+**Uso en PATCH**:
+```typescript
+const validatedUpdates = onboardingSchema.partial().parse(updates);
+```
+
+**Comportamiento de `.partial()`**:
+- Todos los campos se vuelven opcionales
+- Permite PATCH de cualquier combinación de campos
+- Validación sigue activa: si envías `ftp: -10`, falla con ZodError
+
+**Ejemplo**:
+```typescript
+// ✅ Válido: solo actualizar weight
+{ weight: 74 }
+
+// ✅ Válido: actualizar múltiples campos
+{ weight: 74, ftp: 255, goal: "health" }
+
+// ❌ Inválido: ftp negativo
+{ ftp: -10 }
+// → ZodError → 400 Bad Request
+```
+
+---
+
+## 5. Manejo de Errores
+
+**Errores manejados**:
+
+1. **401 Unauthorized** (auth plugin)
+   - Token faltante o inválido
+   - Antes de llegar a la ruta
+
+2. **400 Bad Request** (error handler + ZodError)
+   - Body no cumple schema
+   - Ejemplo: `ftp: "abc"`, `goal: "invalid"`
+
+3. **404 Not Found** (servicio)
+   - Usuario no existe en tabla `users`
+   - Caso raro: token válido pero perfil eliminado
+
+4. **500 Internal Server Error** (error handler)
+   - Error de Supabase
+   - Error inesperado
+
+**Todos capturados por error handler de Bloque 0** → respuesta JSON estructurada.
+
+---
+
+## 6. Testing
+
+### Tests de Integración
+
+**Archivo**: `apps/api/src/routes/profile.test.ts` (futuro)
+
+**Casos**:
+
+```typescript
+describe('GET /api/v1/profile', () => {
+  it('should return user profile with valid token', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/profile',
+      headers: { authorization: `Bearer ${validToken}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: expect.any(String),
+      email: expect.any(String),
+      name: expect.any(String),
+    });
+  });
+
+  it('should return 401 without token', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/profile',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('PATCH /api/v1/profile', () => {
+  it('should update profile with valid data', async () => {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/profile',
+      headers: { authorization: `Bearer ${validToken}` },
+      payload: { weight: 74, ftp: 255 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().weight).toBe(74);
+    expect(response.json().ftp).toBe(255);
+  });
+
+  it('should return 400 with invalid data', async () => {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/profile',
+      headers: { authorization: `Bearer ${validToken}` },
+      payload: { ftp: -10 },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().code).toBe('VALIDATION_ERROR');
+  });
+});
+```
+
+---
+
+## 7. Decisiones Técnicas (ADRs)
+
+### ADR-004: PATCH semántico con .partial()
+
+**Contexto**: Frontend puede actualizar solo algunos campos del perfil.
+
+**Decisión**: Usar `onboardingSchema.partial()` para permitir actualizaciones parciales.
+
+**Consecuencias**:
+- ✅ RESTful correcto (PATCH permite actualizaciones parciales)
+- ✅ Reutiliza schema existente sin duplicación
+- ✅ Validación consistente con onboarding
+- ⚠️ Si se añade campo nuevo a schema, automáticamente se vuelve actualizable
+
+### ADR-005: userId desde request.user
+
+**Contexto**: Usuario autenticado debe poder solo ver/actualizar su propio perfil.
+
+**Decisión**: Extraer `userId` de `request.user` (decorado por auth plugin).
+
+**Consecuencias**:
+- ✅ Seguridad: usuario no puede editar perfiles de otros
+- ✅ No requiere parámetro `:userId` en URL
+- ✅ Consistente con RLS de Supabase (aunque bypaseado con service_role)
+
+### ADR-006: Service layer para lógica de negocio
+
+**Contexto**: Separar lógica de negocio de routing.
+
+**Decisión**: Crear `profile.service.ts` con `getProfile` y `updateProfile`.
+
+**Consecuencias**:
+- ✅ Testeable independientemente de Fastify
+- ✅ Reutilizable (ej: desde endpoint de IA que necesite leer perfil)
+- ✅ Single Responsibility: routes maneja HTTP, service maneja datos
+- ⚠️ Capa extra (pero justificada para proyectos con múltiples endpoints)
+
+---
+
+## 8. Criterios de Aceptación
+
+- [x] `GET /api/v1/profile` retorna perfil del usuario autenticado
+- [x] `GET /api/v1/profile` retorna 401 sin token válido
+- [x] `GET /api/v1/profile` retorna 404 si usuario no existe
+- [x] `PATCH /api/v1/profile` actualiza solo los campos enviados
+- [x] `PATCH /api/v1/profile` valida con `onboardingSchema.partial()`
+- [x] `PATCH /api/v1/profile` retorna 400 si datos inválidos
+- [x] `PATCH /api/v1/profile` retorna perfil actualizado con `updated_at` nuevo
+- [x] Ambos endpoints protegidos con auth hook
+- [x] Errores formateados por error handler centralizado
+
+---
+
+## 9. Archivos Modificados/Creados
+
+**Nuevos**:
+- `apps/api/src/services/profile.service.ts`
+- `apps/api/src/routes/profile.ts`
+
+**Modificados**:
+- `apps/api/src/app.ts` (registro de `profileRoutes`)
+
+---
+
+## 10. Integración con Frontend
+
+**Pantalla**: `/profile` (`apps/web/src/app/(app)/profile/page.tsx`)
+
+**Consumo**:
+```typescript
+// GET profile
+const response = await fetch(`${API_URL}/api/v1/profile`, {
+  headers: {
+    'Authorization': `Bearer ${session.access_token}`,
+  },
+});
+const profile = await response.json();
+
+// PATCH profile
+await fetch(`${API_URL}/api/v1/profile`, {
+  method: 'PATCH',
+  headers: {
+    'Authorization': `Bearer ${session.access_token}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ weight: 74, ftp: 255 }),
+});
+```
+
+**Estado actual**: Frontend consume Supabase directamente. Migración a API en fase futura.
+
+---
+
+## 11. Próximos Pasos (Bloque 2)
+
+Con endpoints de perfil listos, Bloque 2 puede implementar:
+- CRUD completo de actividades (`GET`, `POST`, `PATCH`, `DELETE`)
+- Paginación y filtros en `GET /api/v1/activities`
+- Endpoint `GET /api/v1/activities/:id/metrics` para series temporales
+- Service `activity.service.ts` con cálculo automático de TSS

--- a/docs/specs/L2-backend-02-activities.md
+++ b/docs/specs/L2-backend-02-activities.md
@@ -1,0 +1,808 @@
+# L2 — Diseño Técnico: CRUD de Actividades (Bloque 2)
+
+> **Tipo**: Especificación técnica (L2)
+> **Fase**: 3 — Backend + IA
+> **Bloque**: 2 — Actividades (CRUD completo)
+> **Estado**: ✅ Implementado (retroactivo)
+> **Fecha**: 2026-02-15
+> **Commit**: `ba20cb4`
+
+---
+
+## 1. Objetivo
+
+Implementar CRUD completo de actividades para:
+- Listar actividades con paginación, filtros y búsqueda
+- Obtener detalle de una actividad
+- Crear nueva actividad (con cálculo automático de TSS)
+- Actualizar actividad existente
+- Eliminar actividad
+- Obtener métricas temporales de una actividad (series de potencia/FC/cadencia)
+
+Estos endpoints son consumidos por las pantallas:
+- `/activities` (lista)
+- `/activities/[id]` (detalle)
+- `/activities/import` (crear)
+
+---
+
+## 2. Contratos de API
+
+### 2.1 GET /api/v1/activities
+
+**Propósito**: Listar actividades del usuario con paginación, filtros y búsqueda.
+
+**Autenticación**: ✅ Requerida
+
+**Query Parameters**:
+```typescript
+{
+  page?: number;        // Default: 1
+  limit?: number;       // Default: 10, Max: 100
+  type?: ActivityType;  // intervals | endurance | recovery | tempo | rest
+  search?: string;      // Búsqueda en nombre de actividad
+  sortBy?: string;      // Default: 'date'
+  order?: 'asc' | 'desc'; // Default: 'desc'
+}
+```
+
+**Request**:
+```http
+GET /api/v1/activities?page=1&limit=10&type=endurance&search=sunday HTTP/1.1
+Host: localhost:3001
+Authorization: Bearer <jwt_token>
+```
+
+**Response 200 OK**:
+```json
+{
+  "data": [
+    {
+      "id": "uuid-activity-123",
+      "user_id": "uuid-user-123",
+      "name": "Sunday Long Ride",
+      "activity_type": "endurance",
+      "date": "2026-02-14T08:00:00.000Z",
+      "duration": 7200,
+      "distance": 80000,
+      "avg_power": 210,
+      "normalized_power": 220,
+      "avg_hr": 145,
+      "avg_cadence": 85,
+      "elevation_gain": 1200,
+      "tss": 180,
+      "rpe": 7,
+      "notes": "Great ride, felt strong",
+      "ai_analysis": { "summary": "Well-paced endurance ride..." },
+      "created_at": "2026-02-14T10:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 45,
+    "totalPages": 5
+  }
+}
+```
+
+**Paginación**:
+- `page`: Página actual (base 1)
+- `limit`: Actividades por página
+- `total`: Total de actividades (después de filtros)
+- `totalPages`: Ceil(total / limit)
+
+**Filtros**:
+- `type`: Solo actividades del tipo especificado
+- `search`: Búsqueda insensible a mayúsculas en campo `name` (ILIKE)
+
+**Ordenamiento**:
+- Default: `date DESC` (más recientes primero)
+- Soporta `asc`/`desc` en cualquier campo
+
+---
+
+### 2.2 GET /api/v1/activities/:id
+
+**Propósito**: Obtener detalle completo de una actividad.
+
+**Autenticación**: ✅ Requerida
+
+**Request**:
+```http
+GET /api/v1/activities/uuid-activity-123 HTTP/1.1
+Authorization: Bearer <jwt_token>
+```
+
+**Response 200 OK**:
+```json
+{
+  "id": "uuid-activity-123",
+  "user_id": "uuid-user-123",
+  "name": "Sunday Long Ride",
+  "activity_type": "endurance",
+  "date": "2026-02-14T08:00:00.000Z",
+  "duration": 7200,
+  "distance": 80000,
+  "avg_power": 210,
+  "normalized_power": 220,
+  "avg_hr": 145,
+  "avg_cadence": 85,
+  "elevation_gain": 1200,
+  "tss": 180,
+  "rpe": 7,
+  "notes": "Great ride, felt strong",
+  "is_reference": false,
+  "ai_analysis": {
+    "summary": "Well-paced endurance ride...",
+    "strengths": ["Consistent power", "Good pacing"],
+    "areas_to_improve": ["Cadence could be higher"],
+    "next_steps": ["Focus on Z2 work"]
+  },
+  "created_at": "2026-02-14T10:00:00.000Z",
+  "updated_at": "2026-02-14T10:00:00.000Z"
+}
+```
+
+**Response 404 Not Found**:
+```json
+{
+  "error": "Activity not found",
+  "code": "NOT_FOUND"
+}
+```
+
+**Validación de ownership**: Query filtra por `user_id = request.user.id` → usuario solo ve sus actividades.
+
+---
+
+### 2.3 POST /api/v1/activities
+
+**Propósito**: Crear nueva actividad (importación manual o desde archivo).
+
+**Autenticación**: ✅ Requerida
+
+**Request**:
+```http
+POST /api/v1/activities HTTP/1.1
+Authorization: Bearer <jwt_token>
+Content-Type: application/json
+
+{
+  "name": "Morning Ride",
+  "activity_type": "endurance",
+  "date": "2026-02-15T07:00:00.000Z",
+  "duration": 3600,
+  "distance": 40000,
+  "avg_power": 200,
+  "normalized_power": 210,
+  "avg_hr": 140,
+  "avg_cadence": 90,
+  "elevation_gain": 500,
+  "rpe": 6,
+  "notes": "Easy spin"
+}
+```
+
+**Validación**: Body validado con `activitySchema` de `@cycling-companion/shared`.
+
+**Campos requeridos**:
+- `name` (string, min 1 char)
+- `activity_type` (enum)
+- `date` (datetime)
+- `duration` (number, > 0, en segundos)
+
+**Campos opcionales**:
+- `distance` (metros)
+- `avg_power`, `normalized_power` (watts)
+- `avg_hr` (bpm)
+- `avg_cadence` (rpm)
+- `elevation_gain` (metros)
+- `rpe` (1-10)
+- `notes` (string)
+
+**Cálculo automático de TSS**:
+Si actividad incluye `avg_power` y usuario tiene `ftp` definido:
+```typescript
+const intensityFactor = avg_power / ftp;
+const tss = Math.round(
+  Math.pow(intensityFactor, 2) * (duration / 3600) * 100
+);
+```
+
+**Response 201 Created**:
+```json
+{
+  "id": "uuid-new-activity",
+  "user_id": "uuid-user-123",
+  "name": "Morning Ride",
+  "activity_type": "endurance",
+  "date": "2026-02-15T07:00:00.000Z",
+  "duration": 3600,
+  "distance": 40000,
+  "avg_power": 200,
+  "normalized_power": 210,
+  "avg_hr": 140,
+  "avg_cadence": 90,
+  "elevation_gain": 500,
+  "tss": 120,  // ← Calculado automáticamente
+  "rpe": 6,
+  "notes": "Easy spin",
+  "ai_analysis": null,
+  "is_reference": false,
+  "created_at": "2026-02-15T08:00:00.000Z",
+  "updated_at": "2026-02-15T08:00:00.000Z"
+}
+```
+
+**Response 400 Bad Request** (validación):
+```json
+{
+  "error": "Validation failed",
+  "code": "VALIDATION_ERROR",
+  "details": [
+    {
+      "path": ["duration"],
+      "message": "Number must be greater than 0"
+    }
+  ]
+}
+```
+
+---
+
+### 2.4 PATCH /api/v1/activities/:id
+
+**Propósito**: Actualizar actividad existente (parcial).
+
+**Autenticación**: ✅ Requerida
+
+**Request**:
+```http
+PATCH /api/v1/activities/uuid-activity-123 HTTP/1.1
+Authorization: Bearer <jwt_token>
+Content-Type: application/json
+
+{
+  "name": "Sunday Long Ride (Updated)",
+  "rpe": 8,
+  "notes": "Harder than expected"
+}
+```
+
+**Validación**: `activitySchema.partial()` (permite campos opcionales).
+
+**Recalculo de TSS**: Si se actualiza `avg_power` o `normalized_power`, TSS se recalcula automáticamente.
+
+**Response 200 OK**: Actividad completa actualizada (igual formato que GET).
+
+**Response 404 Not Found**: Actividad no existe o no pertenece al usuario.
+
+---
+
+### 2.5 DELETE /api/v1/activities/:id
+
+**Propósito**: Eliminar actividad.
+
+**Autenticación**: ✅ Requerida
+
+**Request**:
+```http
+DELETE /api/v1/activities/uuid-activity-123 HTTP/1.1
+Authorization: Bearer <jwt_token>
+```
+
+**Response 204 No Content**: Actividad eliminada exitosamente.
+
+**Response 404 Not Found**: Actividad no existe o no pertenece al usuario.
+
+**Cascade**: Si existen `activity_metrics` asociadas, se eliminan también (FK con ON DELETE CASCADE).
+
+---
+
+### 2.6 GET /api/v1/activities/:id/metrics
+
+**Propósito**: Obtener series temporales de métricas (potencia/FC/cadencia por segundo).
+
+**Autenticación**: ✅ Requerida
+
+**Request**:
+```http
+GET /api/v1/activities/uuid-activity-123/metrics HTTP/1.1
+Authorization: Bearer <jwt_token>
+```
+
+**Response 200 OK**:
+```json
+{
+  "activity_id": "uuid-activity-123",
+  "metrics": [
+    {
+      "timestamp": 0,
+      "power": 200,
+      "heart_rate": 140,
+      "cadence": 90,
+      "speed": 8.5
+    },
+    {
+      "timestamp": 1,
+      "power": 205,
+      "heart_rate": 142,
+      "cadence": 91,
+      "speed": 8.6
+    }
+    // ... hasta duration segundos
+  ]
+}
+```
+
+**Response 200 OK (sin métricas)**:
+```json
+{
+  "activity_id": "uuid-activity-123",
+  "metrics": []
+}
+```
+
+**Response 404 Not Found**: Actividad no existe o no pertenece al usuario.
+
+**Performance**: Si hay miles de puntos, considerar paginación o sampling (futuro).
+
+---
+
+## 3. Arquitectura
+
+### 3.1 Capa de Servicio
+
+**Archivo**: `apps/api/src/services/activity.service.ts`
+
+**Métodos**:
+
+#### `listActivities(userId, filters)`
+
+```typescript
+export async function listActivities(
+  userId: string,
+  filters: ActivityFilters = {}
+) {
+  const {
+    page = 1,
+    limit = 10,
+    type,
+    search,
+    sortBy = 'date',
+    order = 'desc',
+  } = filters;
+
+  let query = supabase
+    .from('activities')
+    .select('*', { count: 'exact' })
+    .eq('user_id', userId);
+
+  // Filtro por tipo
+  if (type) {
+    query = query.eq('activity_type', type);
+  }
+
+  // Búsqueda en nombre
+  if (search) {
+    query = query.ilike('name', `%${search}%`);
+  }
+
+  // Ordenamiento
+  query = query.order(sortBy, { ascending: order === 'asc' });
+
+  // Paginación
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+  query = query.range(from, to);
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    throw new AppError('Failed to fetch activities', 500, 'FETCH_FAILED');
+  }
+
+  return {
+    data: data || [],
+    meta: {
+      page,
+      limit,
+      total: count || 0,
+      totalPages: Math.ceil((count || 0) / limit),
+    },
+  };
+}
+```
+
+#### `getActivity(userId, activityId)`
+
+```typescript
+export async function getActivity(userId: string, activityId: string) {
+  const { data, error } = await supabase
+    .from('activities')
+    .select('*')
+    .eq('id', activityId)
+    .eq('user_id', userId) // Validación de ownership
+    .single();
+
+  if (error || !data) {
+    throw new AppError('Activity not found', 404, 'NOT_FOUND');
+  }
+
+  return data;
+}
+```
+
+#### `createActivity(userId, activityData)`
+
+```typescript
+export async function createActivity(
+  userId: string,
+  activityData: ActivityInput
+) {
+  const validated = activitySchema.parse(activityData);
+
+  // Obtener FTP del usuario para cálculo de TSS
+  const profile = await getProfile(userId);
+
+  // Calcular TSS si hay potencia y FTP
+  let tss: number | null = null;
+  if (validated.avg_power && profile.ftp) {
+    const intensityFactor = validated.avg_power / profile.ftp;
+    tss = Math.round(
+      Math.pow(intensityFactor, 2) * (validated.duration / 3600) * 100
+    );
+  }
+
+  const { data, error } = await supabase
+    .from('activities')
+    .insert({
+      ...validated,
+      user_id: userId,
+      tss,
+    })
+    .select()
+    .single();
+
+  if (error || !data) {
+    throw new AppError('Failed to create activity', 500, 'CREATE_FAILED');
+  }
+
+  return data;
+}
+```
+
+**Lógica TSS**:
+```
+IF² = (avg_power / ftp)²
+TSS = IF² × duration_hours × 100
+
+Ejemplo:
+  avg_power = 200W
+  ftp = 250W
+  duration = 3600s = 1h
+
+  IF = 200/250 = 0.8
+  IF² = 0.64
+  TSS = 0.64 × 1 × 100 = 64
+```
+
+#### `updateActivity(userId, activityId, updates)`
+
+```typescript
+export async function updateActivity(
+  userId: string,
+  activityId: string,
+  updates: Partial<ActivityInput>
+) {
+  const validated = activitySchema.partial().parse(updates);
+
+  // Recalcular TSS si se actualizó potencia
+  let tss: number | null | undefined = validated.tss;
+  if (validated.avg_power !== undefined) {
+    const profile = await getProfile(userId);
+    if (profile.ftp) {
+      const activity = await getActivity(userId, activityId);
+      const power = validated.avg_power ?? activity.avg_power;
+      const duration = validated.duration ?? activity.duration;
+
+      const intensityFactor = power / profile.ftp;
+      tss = Math.round(
+        Math.pow(intensityFactor, 2) * (duration / 3600) * 100
+      );
+    }
+  }
+
+  const { data, error } = await supabase
+    .from('activities')
+    .update({ ...validated, tss })
+    .eq('id', activityId)
+    .eq('user_id', userId)
+    .select()
+    .single();
+
+  if (error || !data) {
+    throw new AppError('Failed to update activity', 500, 'UPDATE_FAILED');
+  }
+
+  return data;
+}
+```
+
+#### `deleteActivity(userId, activityId)`
+
+```typescript
+export async function deleteActivity(userId: string, activityId: string) {
+  const { error } = await supabase
+    .from('activities')
+    .delete()
+    .eq('id', activityId)
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new AppError('Failed to delete activity', 500, 'DELETE_FAILED');
+  }
+
+  return { success: true };
+}
+```
+
+#### `getActivityMetrics(userId, activityId)`
+
+```typescript
+export async function getActivityMetrics(userId: string, activityId: string) {
+  // Verificar ownership
+  await getActivity(userId, activityId);
+
+  const { data, error } = await supabase
+    .from('activity_metrics')
+    .select('*')
+    .eq('activity_id', activityId)
+    .order('timestamp', { ascending: true });
+
+  if (error) {
+    throw new AppError('Failed to fetch metrics', 500, 'FETCH_FAILED');
+  }
+
+  return {
+    activity_id: activityId,
+    metrics: data || [],
+  };
+}
+```
+
+---
+
+### 3.2 Capa de Rutas
+
+**Archivo**: `apps/api/src/routes/activities.ts`
+
+```typescript
+import type { FastifyInstance } from 'fastify';
+import {
+  listActivities,
+  getActivity,
+  createActivity,
+  updateActivity,
+  deleteActivity,
+  getActivityMetrics,
+} from '../services/activity.service';
+
+export default async function activityRoutes(fastify: FastifyInstance) {
+  // GET /api/v1/activities
+  fastify.get('/activities', async (request) => {
+    const userId = request.user!.id;
+    const filters = request.query as ActivityFilters;
+    return await listActivities(userId, filters);
+  });
+
+  // GET /api/v1/activities/:id
+  fastify.get<{ Params: { id: string } }>(
+    '/activities/:id',
+    async (request) => {
+      const userId = request.user!.id;
+      const { id } = request.params;
+      return await getActivity(userId, id);
+    }
+  );
+
+  // POST /api/v1/activities
+  fastify.post('/activities', async (request) => {
+    const userId = request.user!.id;
+    const activityData = request.body as ActivityInput;
+    const created = await createActivity(userId, activityData);
+    return created;
+  });
+
+  // PATCH /api/v1/activities/:id
+  fastify.patch<{ Params: { id: string } }>(
+    '/activities/:id',
+    async (request) => {
+      const userId = request.user!.id;
+      const { id } = request.params;
+      const updates = request.body as Partial<ActivityInput>;
+      return await updateActivity(userId, id, updates);
+    }
+  );
+
+  // DELETE /api/v1/activities/:id
+  fastify.delete<{ Params: { id: string } }>(
+    '/activities/:id',
+    async (request, reply) => {
+      const userId = request.user!.id;
+      const { id } = request.params;
+      await deleteActivity(userId, id);
+      reply.status(204).send();
+    }
+  );
+
+  // GET /api/v1/activities/:id/metrics
+  fastify.get<{ Params: { id: string } }>(
+    '/activities/:id/metrics',
+    async (request) => {
+      const userId = request.user!.id;
+      const { id } = request.params;
+      return await getActivityMetrics(userId, id);
+    }
+  );
+}
+```
+
+**Registro en app.ts**:
+```typescript
+await app.register(activityRoutes); // Dentro del scope protegido
+```
+
+---
+
+## 4. Validación de Datos
+
+**Schema Zod**: `packages/shared/src/schemas/activity.ts`
+
+```typescript
+export const activitySchema = z.object({
+  name: z.string().min(1),
+  activity_type: z.enum(['intervals', 'endurance', 'recovery', 'tempo', 'rest']),
+  date: z.string().datetime(),
+  duration: z.number().positive(),
+  distance: z.number().nonnegative().optional(),
+  avg_power: z.number().nonnegative().optional(),
+  normalized_power: z.number().nonnegative().optional(),
+  avg_hr: z.number().positive().optional(),
+  avg_cadence: z.number().nonnegative().optional(),
+  elevation_gain: z.number().nonnegative().optional(),
+  rpe: z.number().int().min(1).max(10).optional(),
+  notes: z.string().optional(),
+});
+```
+
+**Uso**:
+- POST: `activitySchema.parse(body)`
+- PATCH: `activitySchema.partial().parse(body)`
+
+---
+
+## 5. Testing
+
+**Casos clave**:
+
+```typescript
+describe('GET /api/v1/activities', () => {
+  it('should paginate correctly', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/activities?page=2&limit=5',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.json().meta).toEqual({
+      page: 2,
+      limit: 5,
+      total: expect.any(Number),
+      totalPages: expect.any(Number),
+    });
+  });
+
+  it('should filter by type', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/activities?type=endurance',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.json().data.every(a => a.activity_type === 'endurance')).toBe(true);
+  });
+});
+
+describe('POST /api/v1/activities', () => {
+  it('should calculate TSS automatically', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/activities',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        name: 'Test Ride',
+        activity_type: 'endurance',
+        date: new Date().toISOString(),
+        duration: 3600,
+        avg_power: 200, // Asume FTP=250 → TSS=64
+      },
+    });
+
+    expect(response.json().tss).toBe(64);
+  });
+});
+```
+
+---
+
+## 6. Decisiones Técnicas (ADRs)
+
+### ADR-007: Cálculo automático de TSS
+
+**Decisión**: Calcular TSS en backend al crear/actualizar actividad.
+
+**Rationale**:
+- ✅ Consistencia: mismo algoritmo para todos los clientes
+- ✅ No exponer lógica de cálculo al frontend
+- ✅ Requiere FTP del usuario (disponible en backend)
+
+**Fórmula**: `TSS = IF² × duration_hours × 100` donde `IF = avg_power / ftp`
+
+### ADR-008: Paginación con meta
+
+**Decisión**: Retornar `{ data, meta }` en listados.
+
+**Rationale**:
+- ✅ Frontend puede construir UI de paginación
+- ✅ Estándar en APIs REST
+- ✅ Incluye `totalPages` para simplificar lógica de UI
+
+### ADR-009: Filtro de ownership implícito
+
+**Decisión**: Queries filtran siempre por `user_id` del token.
+
+**Rationale**:
+- ✅ Seguridad: usuario solo ve sus actividades
+- ✅ No requiere RLS activo (aunque backend usa service_role)
+- ✅ Consistente con principio de autorización en API layer
+
+---
+
+## 7. Criterios de Aceptación
+
+- [x] `GET /api/v1/activities` retorna lista paginada
+- [x] Paginación con `page`, `limit`, `total`, `totalPages`
+- [x] Filtro por `type` funcional
+- [x] Búsqueda por `search` en nombre (case-insensitive)
+- [x] `GET /api/v1/activities/:id` retorna actividad completa
+- [x] `POST /api/v1/activities` crea actividad con TSS calculado
+- [x] `PATCH /api/v1/activities/:id` actualiza parcialmente
+- [x] TSS se recalcula si se actualiza `avg_power`
+- [x] `DELETE /api/v1/activities/:id` elimina actividad
+- [x] `GET /api/v1/activities/:id/metrics` retorna series temporales
+- [x] Todos los endpoints validan ownership (user_id)
+- [x] Errores formateados por error handler
+
+---
+
+## 8. Archivos Modificados/Creados
+
+**Nuevos**:
+- `apps/api/src/services/activity.service.ts`
+- `apps/api/src/routes/activities.ts`
+
+**Modificados**:
+- `apps/api/src/app.ts` (registro de `activityRoutes`)
+
+---
+
+## 9. Próximos Pasos (Bloque 3)
+
+Con CRUD de actividades completo, Bloque 3 puede implementar:
+- `POST /api/v1/activities/upload` (parseo .fit/.gpx)
+- `POST /api/v1/ai/analyze-activity` (análisis IA post-sesión)
+- `POST /api/v1/ai/weekly-plan` (generación plan semanal)
+- `GET /api/v1/ai/coach-tip` (recomendación del día para dashboard)
+- `POST /api/v1/ai/weekly-summary` (resumen comparativo para insights)

--- a/docs/specs/phase3-backend-plan.md
+++ b/docs/specs/phase3-backend-plan.md
@@ -1,6 +1,31 @@
 # Plan de Desarrollo — Fase 3: Backend + IA
 
 > Generado: 2026-02-15 | Metodología: Pipeline AI-first con agentes locales
+> **Actualizado**: 2026-02-15 — Documentación de metodología híbrida (Bloques 0-2 vs Bloque 3+)
+
+---
+
+## ⚠️ Nota Metodológica
+
+**Bloques 0-2 (Infraestructura, Perfil, Actividades):**
+- **Proceso seguido**: Implementación directa desde este plan general → commit
+- **Documentación**: Specs L2 (diseño técnico) generadas **retroactivamente** tras implementación
+- **Rationale**: Contratos de API bien definidos en PRD, schemas Zod compartidos ya existentes, iteración rápida
+
+**Bloque 3+ (Importación + IA):**
+- **Proceso a seguir**: Pipeline completo L1 → L2 → L3 → L4 → L5
+- **Documentación**: Specs L1/L2/L3 generadas **antes** de implementar
+- **Rationale**: Lógica IA más compleja, prompts a diseñar, mayor beneficio de diseño previo
+
+**Justificación del cambio**:
+- Bloques 0-2 eran más predecibles (CRUD estándar)
+- Bloque 3 (IA) requiere más diseño upfront (prompts, parseo archivos, integración Claude API)
+- Aprendizaje del proceso: aplicar pipeline completo donde aporta más valor
+
+**Archivos de specs retroactivas**:
+- `docs/specs/L2-backend-00-infrastructure.md` (Bloque 0)
+- `docs/specs/L2-backend-01-profile.md` (Bloque 1)
+- `docs/specs/L2-backend-02-activities.md` (Bloque 2)
 
 ---
 


### PR DESCRIPTION
## 🎯 Objetivo

Documentar retroactivamente el diseño técnico (L2) de los bloques 0-2 de Fase 3 (Backend) e implementar metodología híbrida para el resto de la fase.

## 📦 Cambios Implementados

### Specs L2 Retroactivas (3 archivos)

#### ✨ `L2-backend-00-infrastructure.md` (Bloque 0)
**Documenta infraestructura base del backend:**
- Factory pattern (`app.ts` separado de `index.ts`)
- Validación env vars con Zod (`config/env.ts`)
- Plugins: CORS, auth JWT Supabase, error handler centralizado
- Servicios: clientes Supabase (service_role) y Anthropic
- ADRs: testabilidad, service_role_key, fastify-plugin

**Archivos implementados** (commit `a721d43`):
- `apps/api/src/app.ts`, `index.ts`
- `plugins/cors.ts`, `auth.ts`, `error-handler.ts`
- `config/env.ts`, `services/supabase.ts`, `services/anthropic.ts`

---

#### ✨ `L2-backend-01-profile.md` (Bloque 1)
**Documenta endpoints de perfil:**
- `GET /api/v1/profile`: obtener perfil del usuario autenticado
- `PATCH /api/v1/profile`: actualización parcial con validación Zod
- Service layer: `profile.service.ts` (separación de concerns)
- ADRs: PATCH semántico con `.partial()`, userId desde `request.user`

**Archivos implementados** (commit `b9da9a8`):
- `services/profile.service.ts`
- `routes/profile.ts`

---

#### ✨ `L2-backend-02-activities.md` (Bloque 2)
**Documenta CRUD completo de actividades:**
- `GET /api/v1/activities`: lista con paginación, filtros, búsqueda
- `GET /api/v1/activities/:id`: detalle
- `POST /api/v1/activities`: crear con **cálculo automático de TSS**
- `PATCH /api/v1/activities/:id`: actualizar (recalcula TSS si cambia potencia)
- `DELETE /api/v1/activities/:id`: eliminar
- `GET /api/v1/activities/:id/metrics`: series temporales
- ADRs: TSS automático (IF² × duration_hours × 100), paginación con meta, ownership implícito

**Archivos implementados** (commit `ba20cb4`):
- `services/activity.service.ts` (6 métodos)
- `routes/activities.ts` (6 endpoints)

---

### Documentación de Metodología

#### 📝 `phase3-backend-plan.md` (actualizado)
**Añadida nota metodológica:**
```
⚠️ Nota Metodológica

Bloques 0-2: Implementación directa → specs L2 retroactivas
Bloque 3+: Pipeline L1→L2→L3→L4→L5 completo → specs previas

Rationale:
- Bloques 0-2: CRUD predecible, contratos claros en PRD
- Bloque 3: IA compleja, mayor beneficio de diseño previo
```

#### 📝 `CLAUDE.md` (actualizado)
**Nueva sección "Metodología por Fase":**
- Fase 2 (Frontend): pipeline completo, 22 specs
- Fase 3 Bloques 0-2: implementación directa, specs retroactivas
- Fase 3 Bloque 3+: pipeline completo
- **Conclusión**: metodología híbrida según complejidad

---

## 📊 Estructura de Cada Spec L2

Todas las specs siguen formato uniforme:

1. **Objetivo**: Qué implementa el bloque
2. **Contratos de API**: Request/Response de cada endpoint (si aplica)
3. **Arquitectura**: Service layer, routes, plugins
4. **Validación**: Schemas Zod reutilizados de `shared`
5. **Manejo de Errores**: Tipos de error capturados
6. **Testing**: Estrategia y casos clave
7. **ADRs**: Decisiones técnicas con rationale
8. **Criterios de Aceptación**: Checklist verificable
9. **Archivos Creados/Modificados**: Lista completa
10. **Próximos Pasos**: Link al siguiente bloque

---

## 🤔 Rationale del Enfoque Híbrido

### ¿Por qué specs retroactivas para Bloques 0-2?

**Ventajas de haberlas generado antes:**
- Diseño más deliberado, menos refactors
- Documentación clara para reviewers

**Realidad de lo que ocurrió:**
- Contratos API bien definidos en PRD
- Schemas Zod ya existentes en `packages/shared`
- Iteración rápida: plan general → código → commit

**Decisión:**
- ✅ Generar specs retroactivas (1.5h) para consistencia documental
- ✅ Aprender del proceso: aplicar pipeline completo a partir de Bloque 3

### ¿Por qué pipeline completo para Bloque 3+?

**Bloque 3 (Import + IA) es más complejo:**
- Parseo .fit/.gpx (múltiples librerías candidatas)
- Prompts IA a diseñar y testear
- Integración Claude API (errores, rate limits, costes)
- Almacenamiento en Supabase Storage

**Beneficio del diseño previo:**
- Explorar alternativas (fit-parser vs fit-file-parser)
- Diseñar prompts estructurados antes de implementar
- Definir strategy de fallback si Claude API falla

---

## ✅ Checklist

- [x] Spec L2 Bloque 0 (infraestructura) — 9 secciones, ~1200 líneas
- [x] Spec L2 Bloque 1 (perfil) — 11 secciones, ~650 líneas
- [x] Spec L2 Bloque 2 (actividades) — 9 secciones, ~900 líneas
- [x] Actualizar `phase3-backend-plan.md` con nota metodológica
- [x] Actualizar `CLAUDE.md` con sección "Metodología por Fase"
- [x] Verificar formato consistente entre las 3 specs
- [x] Commit message descriptivo explicando rationale

---

## 📈 Métricas

| Métrica | Valor |
|---------|-------|
| **Specs L2 creadas** | 3 (retroactivas) |
| **Líneas de documentación** | ~2750 |
| **Bloques documentados** | 0, 1, 2 (de 4 totales) |
| **ADRs documentadas** | 9 decisiones técnicas |
| **Endpoints documentados** | 9 (2 perfil + 6 actividades + 1 health) |

---

## 🎯 Próximos Pasos

**Bloque 3 (Import + IA):**
1. Aplicar pipeline completo: L1 → L2 → L3 → L4 → L5
2. Generar specs **antes** de implementar
3. Explorar librerías de parseo .fit/.gpx
4. Diseñar prompts para Claude API:
   - Análisis post-sesión
   - Generación plan semanal
   - Tip del coach (dashboard)
   - Resumen comparativo (insights)

**Objetivo**: Demostrar consistentemente el pipeline AI-first en features complejas donde aporta máximo valor.

---

**Relacionado con**: Fase 3 — Backend + IA (documentación de proceso)