### PR TITLE
feat: añadir endpoints de insights y overload-check al backend API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
@@ -24,6 +26,7 @@
   "devDependencies": {
     "@types/node": "^22.10.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.0"
   }
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import authPlugin from "./plugins/auth.js";
 import healthRoutes from "./routes/health.js";
 import profileRoutes from "./routes/profile.js";
 import activityRoutes from "./routes/activities.js";
+import insightsRoutes from "./routes/insights.js";
 
 /**
  * Factory function to build and configure the Fastify application.
@@ -31,6 +32,7 @@ export async function buildApp(opts: FastifyServerOptions = {}): Promise<Fastify
       await scope.register(authPlugin);
       await scope.register(profileRoutes);
       await scope.register(activityRoutes);
+      await scope.register(insightsRoutes);
     },
     { prefix: "/api/v1" },
   );

--- a/apps/api/src/plugins/error-handler.test.ts
+++ b/apps/api/src/plugins/error-handler.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { ZodError } from "zod";
+import { AppError, errorHandler } from "./error-handler.js";
+
+describe("AppError", () => {
+  it("creates with default statusCode 500 and code INTERNAL_ERROR", () => {
+    const error = new AppError("Something went wrong");
+    expect(error.message).toBe("Something went wrong");
+    expect(error.statusCode).toBe(500);
+    expect(error.code).toBe("INTERNAL_ERROR");
+  });
+
+  it("creates with custom statusCode and code", () => {
+    const error = new AppError("Resource not found", 404, "NOT_FOUND");
+    expect(error.message).toBe("Resource not found");
+    expect(error.statusCode).toBe(404);
+    expect(error.code).toBe("NOT_FOUND");
+  });
+
+  it("has name AppError", () => {
+    const error = new AppError("Test");
+    expect(error.name).toBe("AppError");
+  });
+
+  it("is instanceof Error", () => {
+    const error = new AppError("Test");
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("errorHandler plugin", () => {
+  let app: FastifyInstance;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  async function buildTestApp() {
+    const fastify = Fastify({ logger: false });
+    await fastify.register(errorHandler);
+    return fastify;
+  }
+
+  beforeEach(async () => {
+    app = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("handles ZodError with 400 and VALIDATION_ERROR code", async () => {
+    app.get("/test", async () => {
+      throw new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "number",
+          path: ["name"],
+          message: "Expected string",
+        },
+      ]);
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("includes ZodError details in development", async () => {
+    delete process.env.NODE_ENV;
+    app = await buildTestApp();
+    app.get("/test", async () => {
+      throw new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "number",
+          path: ["email"],
+          message: "Expected string, received number",
+        },
+      ]);
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.details).toBeDefined();
+    expect(Array.isArray(body.details)).toBe(true);
+  });
+
+  it("excludes ZodError details in production", async () => {
+    process.env.NODE_ENV = "production";
+    app = await buildTestApp();
+    app.get("/test", async () => {
+      const err = new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "number",
+          path: ["name"],
+          message: "Expected string",
+        },
+      ]);
+      (err as ZodError & { statusCode: number }).statusCode = 400;
+      throw err;
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.details).toBeUndefined();
+  });
+
+  it("handles AppError 404 with NOT_FOUND code", async () => {
+    app.get("/test", async () => {
+      throw new AppError("Resource not found", 404, "NOT_FOUND");
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(404);
+    const body = response.json();
+    expect(body.code).toBe("NOT_FOUND");
+  });
+
+  it("handles AppError 500", async () => {
+    app.get("/test", async () => {
+      throw new AppError("Internal error occurred");
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(500);
+    const body = response.json();
+    expect(body.code).toBe("INTERNAL_ERROR");
+  });
+
+  it("handles generic Error with 500", async () => {
+    app.get("/test", async () => {
+      throw new Error("Something broke");
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(500);
+  });
+
+  it("hides error details in production for generic errors", async () => {
+    process.env.NODE_ENV = "production";
+    app = await buildTestApp();
+    app.get("/test", async () => {
+      throw new Error("Sensitive internal details");
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+    expect(response.statusCode).toBe(500);
+    const body = response.json();
+    expect(body.error || body.message).not.toContain("Sensitive");
+  });
+});

--- a/apps/api/src/plugins/error-handler.ts
+++ b/apps/api/src/plugins/error-handler.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyError, FastifyReply, FastifyRequest } from "fastify";
+import fp from "fastify-plugin";
 import { ZodError } from "zod";
 
 /**
@@ -27,7 +28,7 @@ interface ErrorResponse {
 /**
  * Fastify plugin for centralized error handling.
  */
-export async function errorHandler(fastify: FastifyInstance) {
+async function errorHandlerPlugin(fastify: FastifyInstance) {
   fastify.setErrorHandler(
     (
       error: FastifyError | AppError | ZodError | Error,
@@ -124,3 +125,5 @@ function getErrorCode(statusCode: number): string {
       return statusCode >= 500 ? "INTERNAL_ERROR" : "CLIENT_ERROR";
   }
 }
+
+export const errorHandler = fp(errorHandlerPlugin);

--- a/apps/api/src/routes/insights.ts
+++ b/apps/api/src/routes/insights.ts
@@ -1,0 +1,42 @@
+import type { FastifyInstance } from "fastify";
+import { AppError } from "../plugins/error-handler.js";
+import { getInsights, checkOverload } from "../services/insights.service.js";
+
+export default async function insightsRoutes(fastify: FastifyInstance) {
+  fastify.get("/insights", async (request) => {
+    const query = request.query as {
+      period_a_start?: string;
+      period_a_end?: string;
+      period_b_start?: string;
+      period_b_end?: string;
+    };
+
+    if (
+      !query.period_a_start ||
+      !query.period_a_end ||
+      !query.period_b_start ||
+      !query.period_b_end
+    ) {
+      throw new AppError(
+        "Missing required query params: period_a_start, period_a_end, period_b_start, period_b_end",
+        400,
+        "BAD_REQUEST",
+      );
+    }
+
+    const result = await getInsights(
+      request.userId,
+      query.period_a_start,
+      query.period_a_end,
+      query.period_b_start,
+      query.period_b_end,
+    );
+
+    return { data: result };
+  });
+
+  fastify.get("/insights/overload-check", async (request) => {
+    const result = await checkOverload(request.userId);
+    return { data: result };
+  });
+}

--- a/apps/api/src/routes/routes.integration.test.ts
+++ b/apps/api/src/routes/routes.integration.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+
+vi.mock("../config/env.js", () => ({
+  env: {
+    SUPABASE_URL: "https://test.supabase.co",
+    SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+    ANTHROPIC_API_KEY: "test-anthropic-key",
+    PORT: 3001,
+    FRONTEND_URL: "http://localhost:3000",
+  },
+}));
+
+vi.mock("../services/supabase.js", () => ({
+  supabaseAdmin: {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+const { buildApp } = await import("../app.js");
+const { supabaseAdmin } = await import("../services/supabase.js");
+
+const mockProfile = {
+  id: "user-123",
+  email: "test@example.com",
+  display_name: "Test User",
+  age: 42,
+  weight_kg: 75.5,
+  ftp: 250,
+  max_hr: 185,
+  rest_hr: 55,
+  goal: "performance",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const mockActivity = {
+  id: "act-123",
+  user_id: "user-123",
+  name: "Morning Ride",
+  date: "2026-02-10",
+  type: "endurance",
+  duration_seconds: 3600,
+  distance_km: 30.5,
+  avg_power_watts: 200,
+  avg_hr_bpm: 145,
+  max_hr_bpm: 175,
+  avg_cadence_rpm: 85,
+  tss: 55,
+  rpe: 6,
+  ai_analysis: null,
+  notes: null,
+  is_reference: false,
+  raw_file_url: null,
+  created_at: "2026-02-10T08:00:00Z",
+  updated_at: "2026-02-10T08:00:00Z",
+};
+
+const authHeaders = { Authorization: "Bearer test-token" };
+
+function mockAuthSuccess() {
+  vi.mocked(supabaseAdmin.auth.getUser).mockResolvedValue({
+    data: { user: { id: "user-123", email: "test@example.com" } },
+    error: null,
+  } as ReturnType<typeof supabaseAdmin.auth.getUser> extends Promise<infer R> ? R : never);
+}
+
+function mockAuthFailure() {
+  vi.mocked(supabaseAdmin.auth.getUser).mockResolvedValue({
+    data: { user: null },
+    error: { message: "Invalid token" },
+  } as ReturnType<typeof supabaseAdmin.auth.getUser> extends Promise<infer R> ? R : never);
+}
+
+function mockFromChain(result: { data: unknown; error: unknown; count?: number | null }) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockResolvedValue(result),
+    single: vi.fn().mockResolvedValue(result),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+  };
+  vi.mocked(supabaseAdmin.from).mockReturnValue(chain as ReturnType<typeof supabaseAdmin.from>);
+  return chain;
+}
+
+describe("API Integration", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockAuthSuccess();
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe("Health (público)", () => {
+    it("GET /health devuelve 200 con status ok", async () => {
+      const res = await app.inject({ method: "GET", url: "/health" });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ status: "ok" });
+    });
+
+    it("GET /health funciona sin token", async () => {
+      mockAuthFailure();
+      const res = await app.inject({ method: "GET", url: "/health" });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("Auth", () => {
+    it("sin Authorization header devuelve 401", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/profile" });
+      expect(res.statusCode).toBe(401);
+      expect(res.json()).toMatchObject({ error: "Unauthorized" });
+    });
+
+    it("con token inválido devuelve 401", async () => {
+      mockAuthFailure();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/profile",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("con Bearer token válido pasa auth", async () => {
+      mockFromChain({ data: mockProfile, error: null });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/profile",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("Profile", () => {
+    it("GET /api/v1/profile devuelve 200 con perfil", async () => {
+      mockFromChain({ data: mockProfile, error: null });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/profile",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ data: mockProfile });
+    });
+
+    it("PATCH /api/v1/profile devuelve 200 con perfil actualizado", async () => {
+      const updated = { ...mockProfile, ftp: 260 };
+      mockFromChain({ data: updated, error: null });
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/profile",
+        headers: authHeaders,
+        payload: { ftp: 260 },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ data: updated });
+    });
+  });
+
+  describe("Activities", () => {
+    it("GET /api/v1/activities devuelve 200 con lista paginada", async () => {
+      mockFromChain({ data: [mockActivity], error: null, count: 1 });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/activities",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data).toEqual([mockActivity]);
+      expect(body.meta).toMatchObject({ page: 1, limit: 20, total: 1 });
+    });
+
+    it("GET /api/v1/activities/:id devuelve 200 con detalle", async () => {
+      mockFromChain({ data: mockActivity, error: null });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/activities/act-123",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ data: mockActivity });
+    });
+
+    it("POST /api/v1/activities devuelve 201 con actividad creada", async () => {
+      const chain = mockFromChain({ data: mockActivity, error: null });
+      chain.single
+        .mockResolvedValueOnce({ data: mockProfile, error: null })
+        .mockResolvedValueOnce({ data: mockActivity, error: null });
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/activities",
+        headers: authHeaders,
+        payload: {
+          name: "Morning Ride",
+          date: "2026-02-10",
+          type: "endurance",
+          duration_seconds: 3600,
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json()).toEqual({ data: mockActivity });
+    });
+
+    it("DELETE /api/v1/activities/:id devuelve 204", async () => {
+      const lastEq = vi.fn().mockResolvedValue({ error: null, count: 1 });
+      const firstEq = vi.fn().mockReturnValue({ eq: lastEq });
+      const deleteFn = vi.fn().mockReturnValue({ eq: firstEq });
+      vi.mocked(supabaseAdmin.from).mockReturnValue({
+        delete: deleteFn,
+      } as ReturnType<typeof supabaseAdmin.from>);
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/api/v1/activities/act-123",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(204);
+      expect(res.body).toBe("");
+    });
+  });
+
+  describe("Insights", () => {
+    it("GET /api/v1/insights sin query params devuelve 400", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/insights",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("GET /api/v1/insights con periodos devuelve 200 con estructura correcta", async () => {
+      const mockInsightActivities = [
+        {
+          date: "2026-02-10",
+          duration_seconds: 3600,
+          distance_km: 30,
+          avg_power_watts: 200,
+          avg_hr_bpm: 140,
+          tss: 55,
+        },
+      ];
+      const chain = mockFromChain({ data: mockInsightActivities, error: null });
+      // getInsights calls supabase.from("activities") twice via Promise.all
+      // Both calls go through the same mock chain, both resolve with the same data
+      chain.lte.mockResolvedValue({ data: mockInsightActivities, error: null });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/insights?period_a_start=2026-02-01&period_a_end=2026-02-07&period_b_start=2026-02-08&period_b_end=2026-02-15",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data).toHaveProperty("comparison");
+      expect(body.data).toHaveProperty("radar");
+      expect(body.data).toHaveProperty("analysis");
+      expect(body.data.comparison).toHaveLength(6);
+      expect(body.data.radar).toHaveLength(5);
+    });
+
+    it("GET /api/v1/insights/overload-check devuelve 200 con estructura correcta", async () => {
+      // checkOverload calls from() twice via Promise.all.
+      // First chain ends with .gte() (no .lte()), second ends with .lte().
+      // Use thenable chains so any method can be the terminal.
+      function createThenableChain(result: { data: unknown; error: unknown }) {
+        function chainLink(): Record<string, unknown> {
+          const link: Record<string, unknown> = {};
+          for (const m of ["select", "eq", "gte", "lte"]) {
+            link[m] = vi.fn().mockImplementation(() => chainLink());
+          }
+          link["then"] = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+            Promise.resolve(result).then(resolve, reject);
+          return link;
+        }
+        return chainLink();
+      }
+
+      vi.mocked(supabaseAdmin.from).mockImplementation(() => {
+        const result = { data: [], error: null };
+        return createThenableChain(result) as ReturnType<typeof supabaseAdmin.from>;
+      });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/insights/overload-check",
+        headers: authHeaders,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data).toHaveProperty("currentLoad");
+      expect(body.data).toHaveProperty("avgLoad");
+      expect(body.data).toHaveProperty("percentage");
+      expect(body.data).toHaveProperty("is_overloaded");
+      expect(body.data).toHaveProperty("alert_level");
+    });
+
+    it("GET /api/v1/insights sin auth devuelve 401", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/insights?period_a_start=2026-02-01&period_a_end=2026-02-07&period_b_start=2026-02-08&period_b_end=2026-02-15",
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/api/src/services/activity.service.test.ts
+++ b/apps/api/src/services/activity.service.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppError } from "../plugins/error-handler.js";
+import { supabaseAdmin } from "./supabase.js";
+
+vi.mock("./supabase.js", () => ({
+  supabaseAdmin: {
+    from: vi.fn(),
+  },
+}));
+
+const mockFrom = vi.mocked(supabaseAdmin.from);
+
+function mockSupabaseChain(result: {
+  data: unknown;
+  error: { message: string } | null;
+  count?: number | null;
+}) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockResolvedValue(result),
+    single: vi.fn().mockResolvedValue(result),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+  };
+  mockFrom.mockReturnValue(chain as ReturnType<typeof mockFrom>);
+  return chain;
+}
+
+const { listActivities, getActivity, createActivity, updateActivity, deleteActivity } =
+  await import("./activity.service.js");
+
+const mockActivity = {
+  id: "act-123",
+  user_id: "user-123",
+  name: "Morning Ride",
+  date: "2026-02-10",
+  type: "endurance",
+  duration_seconds: 3600,
+  distance_km: 30.5,
+  avg_power_watts: 200,
+  avg_hr_bpm: 145,
+  max_hr_bpm: 175,
+  avg_cadence_rpm: 85,
+  tss: 55,
+  rpe: 6,
+  ai_analysis: null,
+  notes: null,
+  is_reference: false,
+  raw_file_url: null,
+  created_at: "2026-02-10T08:00:00Z",
+  updated_at: "2026-02-10T08:00:00Z",
+};
+
+describe("activity.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listActivities", () => {
+    it("devuelve lista paginada con meta correcta", async () => {
+      mockSupabaseChain({ data: [mockActivity], error: null, count: 1 });
+      const result = await listActivities({ userId: "user-123" });
+      expect(result.data).toEqual([mockActivity]);
+      expect(result.meta).toEqual({ page: 1, limit: 20, total: 1, totalPages: 1 });
+    });
+
+    it("calcula totalPages correctamente", async () => {
+      mockSupabaseChain({ data: Array(20).fill(mockActivity), error: null, count: 45 });
+      const result = await listActivities({ userId: "user-123", page: 1, limit: 20 });
+      expect(result.meta.totalPages).toBe(3);
+    });
+
+    it("aplica filtro por type", async () => {
+      const chain = mockSupabaseChain({ data: [], error: null, count: 0 });
+      await listActivities({ userId: "user-123", type: "intervals" });
+      expect(chain.eq).toHaveBeenCalledWith("type", "intervals");
+    });
+
+    it("aplica filtro dateFrom/dateTo", async () => {
+      const chain = mockSupabaseChain({ data: [], error: null, count: 0 });
+      await listActivities({
+        userId: "user-123",
+        dateFrom: "2026-02-01",
+        dateTo: "2026-02-15",
+      });
+      expect(chain.gte).toHaveBeenCalledWith("date", "2026-02-01");
+      expect(chain.lte).toHaveBeenCalledWith("date", "2026-02-15");
+    });
+
+    it("aplica filtro search con ilike", async () => {
+      const chain = mockSupabaseChain({ data: [], error: null, count: 0 });
+      await listActivities({ userId: "user-123", search: "morning" });
+      expect(chain.or).toHaveBeenCalledWith("name.ilike.%morning%,notes.ilike.%morning%");
+    });
+
+    it("lanza AppError 500 si Supabase falla", async () => {
+      mockSupabaseChain({ data: null, error: { message: "DB error" }, count: null });
+      await expect(listActivities({ userId: "user-123" })).rejects.toThrow(AppError);
+      await expect(listActivities({ userId: "user-123" })).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("getActivity", () => {
+    it("devuelve actividad cuando existe", async () => {
+      mockSupabaseChain({ data: mockActivity, error: null });
+      const result = await getActivity("user-123", "act-123");
+      expect(result).toEqual(mockActivity);
+    });
+
+    it("lanza AppError 404 cuando no existe", async () => {
+      mockSupabaseChain({ data: null, error: null });
+      await expect(getActivity("user-123", "act-999")).rejects.toThrow(AppError);
+      await expect(getActivity("user-123", "act-999")).rejects.toMatchObject({
+        statusCode: 404,
+        code: "NOT_FOUND",
+      });
+    });
+  });
+
+  describe("createActivity", () => {
+    it("calcula TSS cuando hay avg_power_watts y FTP", async () => {
+      const activityData = {
+        name: "Power Ride",
+        date: "2026-02-10",
+        type: "endurance" as const,
+        duration_seconds: 3600,
+        avg_power_watts: 250,
+      };
+      const expectedTss = Math.round(Math.pow(250 / 300, 2) * 1 * 100); // 69
+      mockSupabaseChain({
+        data: { ...mockActivity, ...activityData, tss: expectedTss },
+        error: null,
+      });
+      const result = await createActivity("user-123", activityData, 300);
+      expect(result.tss).toBe(expectedTss);
+    });
+
+    it("devuelve tss=null cuando no hay FTP", async () => {
+      const activityData = {
+        name: "No FTP Ride",
+        date: "2026-02-10",
+        type: "endurance" as const,
+        duration_seconds: 3600,
+        avg_power_watts: 250,
+      };
+      mockSupabaseChain({ data: { ...mockActivity, ...activityData, tss: null }, error: null });
+      const result = await createActivity("user-123", activityData, undefined);
+      expect(result.tss).toBeNull();
+    });
+
+    it("devuelve tss=null cuando no hay avg_power_watts", async () => {
+      const activityData = {
+        name: "No Power Ride",
+        date: "2026-02-10",
+        type: "endurance" as const,
+        duration_seconds: 3600,
+      };
+      mockSupabaseChain({
+        data: { ...mockActivity, ...activityData, avg_power_watts: null, tss: null },
+        error: null,
+      });
+      const result = await createActivity("user-123", activityData, 300);
+      expect(result.tss).toBeNull();
+    });
+
+    it("lanza AppError 500 si Supabase falla en insert", async () => {
+      const activityData = {
+        name: "Fail Ride",
+        date: "2026-02-10",
+        type: "endurance" as const,
+        duration_seconds: 3600,
+      };
+      mockSupabaseChain({ data: null, error: { message: "Insert failed" } });
+      await expect(createActivity("user-123", activityData)).rejects.toThrow(AppError);
+      await expect(createActivity("user-123", activityData)).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("updateActivity", () => {
+    it("actualiza actividad con datos parciales", async () => {
+      const updated = { ...mockActivity, name: "Updated Ride", rpe: 7 };
+      mockSupabaseChain({ data: updated, error: null });
+      const result = await updateActivity("user-123", "act-123", { name: "Updated Ride", rpe: 7 });
+      expect(result).toEqual(updated);
+    });
+
+    it("lanza AppError 404 cuando actividad no existe", async () => {
+      mockSupabaseChain({ data: null, error: null });
+      await expect(updateActivity("user-123", "act-999", { name: "Test" })).rejects.toThrow(
+        AppError,
+      );
+      await expect(updateActivity("user-123", "act-999", { name: "Test" })).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe("deleteActivity", () => {
+    function mockDeleteChain(result: { error: { message: string } | null; count: number | null }) {
+      const lastEq = vi.fn().mockResolvedValue(result);
+      const firstEq = vi.fn().mockReturnValue({ eq: lastEq });
+      const deleteFn = vi.fn().mockReturnValue({ eq: firstEq });
+      mockFrom.mockReturnValue({ delete: deleteFn } as ReturnType<typeof mockFrom>);
+    }
+
+    it("elimina actividad correctamente", async () => {
+      mockDeleteChain({ error: null, count: 1 });
+      await expect(deleteActivity("user-123", "act-123")).resolves.not.toThrow();
+    });
+
+    it("lanza AppError 404 cuando count es 0", async () => {
+      mockDeleteChain({ error: null, count: 0 });
+      await expect(deleteActivity("user-123", "act-999")).rejects.toThrow(AppError);
+      await expect(deleteActivity("user-123", "act-999")).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+
+    it("lanza AppError 500 cuando Supabase falla", async () => {
+      mockDeleteChain({ error: { message: "DB error" }, count: null });
+      await expect(deleteActivity("user-123", "act-123")).rejects.toThrow(AppError);
+      await expect(deleteActivity("user-123", "act-123")).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+  });
+});

--- a/apps/api/src/services/insights.service.test.ts
+++ b/apps/api/src/services/insights.service.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppError } from "../plugins/error-handler.js";
+import { supabaseAdmin } from "./supabase.js";
+
+vi.mock("./supabase.js", () => ({
+  supabaseAdmin: {
+    from: vi.fn(),
+  },
+}));
+
+const mockFrom = vi.mocked(supabaseAdmin.from);
+
+/**
+ * Mock helper that supports sequential calls to supabaseAdmin.from().
+ * Each call to from() returns a fluent chain where every method is both
+ * a passthrough (.mockReturnThis) AND a thenable (resolves to the result).
+ * This way, no matter which method is last in the chain, the promise resolves.
+ */
+function mockFromSequence(results: Array<{ data: unknown; error: unknown }>) {
+  let callIndex = 0;
+  mockFrom.mockImplementation(() => {
+    const result = results[callIndex] ?? results[results.length - 1];
+    callIndex++;
+
+    // Create a thenable chain: each method returns an object that is both
+    // chainable and thenable (has .then)
+    function createChainLink(): Record<string, unknown> {
+      const link: Record<string, unknown> = {};
+      const methods = ["select", "eq", "gte", "lte", "order", "range"];
+      for (const method of methods) {
+        link[method] = vi.fn().mockImplementation(() => createChainLink());
+      }
+      // Make this link thenable so it resolves as a promise
+      link["then"] = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) => {
+        return Promise.resolve(result).then(resolve, reject);
+      };
+      return link;
+    }
+
+    return createChainLink() as ReturnType<typeof mockFrom>;
+  });
+}
+
+const { getInsights, checkOverload } = await import("./insights.service.js");
+
+const makeActivity = (overrides: Record<string, unknown> = {}) => ({
+  date: "2026-02-10",
+  duration_seconds: 3600,
+  distance_km: 30.5,
+  avg_power_watts: 200,
+  avg_hr_bpm: 140,
+  tss: 55,
+  ...overrides,
+});
+
+/**
+ * Helper to generate dates relative to the current Monday (week start).
+ * weekOffset: 0 = current week, -1 = last week, -2 = two weeks ago, etc.
+ * dayOffset: 0 = Monday, 1 = Tuesday, etc.
+ */
+function dateInWeek(weekOffset: number, dayOffset = 0): string {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = now.getDate() - day + (day === 0 ? -6 : 1);
+  const monday = new Date(now);
+  monday.setDate(diff);
+  monday.setHours(0, 0, 0, 0);
+
+  const target = new Date(monday);
+  target.setDate(target.getDate() + weekOffset * 7 + dayOffset);
+  return target.toISOString().split("T")[0];
+}
+
+describe("insights.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getInsights", () => {
+    it("retorna estructura correcta con datos en ambos periodos", async () => {
+      const activitiesA = [makeActivity()];
+      const activitiesB = [makeActivity({ avg_power_watts: 210, distance_km: 35 })];
+      mockFromSequence([
+        { data: activitiesA, error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      expect(result.comparison).toHaveLength(6);
+      expect(result.radar).toHaveLength(5);
+      expect(result.analysis).not.toBeNull();
+    });
+
+    it("retorna analysis null cuando ambos periodos están vacíos", async () => {
+      mockFromSequence([
+        { data: [], error: null },
+        { data: [], error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      expect(result.analysis).toBeNull();
+    });
+
+    it("calcula distancia agregada correctamente (sum + round 1 decimal)", async () => {
+      const activitiesB = [
+        makeActivity({ distance_km: 15.3 }),
+        makeActivity({ distance_km: 20.4 }),
+      ];
+      mockFromSequence([
+        { data: [], error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      const distMetric = result.comparison.find((m) => m.metric === "Distancia");
+      expect(distMetric?.valueB).toBe(35.7);
+    });
+
+    it("calcula potencia media ignorando nulls", async () => {
+      const activitiesB = [
+        makeActivity({ avg_power_watts: 200 }),
+        makeActivity({ avg_power_watts: null }),
+        makeActivity({ avg_power_watts: 300 }),
+      ];
+      mockFromSequence([
+        { data: [], error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      const powerMetric = result.comparison.find((m) => m.metric === "Potencia");
+      expect(powerMetric?.valueB).toBe(250);
+    });
+
+    it("calcula FC media ignorando nulls", async () => {
+      const activitiesB = [
+        makeActivity({ avg_hr_bpm: 140 }),
+        makeActivity({ avg_hr_bpm: null }),
+        makeActivity({ avg_hr_bpm: 160 }),
+      ];
+      mockFromSequence([
+        { data: [], error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      const hrMetric = result.comparison.find((m) => m.metric === "FC media");
+      expect(hrMetric?.valueB).toBe(150);
+    });
+
+    it("genera TSS alert cuando sube >15%", async () => {
+      const activitiesA = [makeActivity({ tss: 100 })];
+      const activitiesB = [makeActivity({ tss: 120 })]; // +20%
+      mockFromSequence([
+        { data: activitiesA, error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      expect(result.analysis?.alert).toBeDefined();
+      expect(result.analysis?.alert).toContain("20%");
+    });
+
+    it("no genera TSS alert cuando sube ≤15%", async () => {
+      const activitiesA = [makeActivity({ tss: 100 })];
+      const activitiesB = [makeActivity({ tss: 110 })]; // +10%
+      mockFromSequence([
+        { data: activitiesA, error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      expect(result.analysis?.alert).toBeUndefined();
+    });
+
+    it("capea valores de radar a 100", async () => {
+      const activitiesB = [makeActivity({ distance_km: 500 })];
+      mockFromSequence([
+        { data: [], error: null },
+        { data: activitiesB, error: null },
+      ]);
+
+      const result = await getInsights(
+        "user-123",
+        "2026-02-01",
+        "2026-02-07",
+        "2026-02-08",
+        "2026-02-15",
+      );
+
+      const volumen = result.radar.find((r) => r.metric === "Volumen");
+      expect(volumen?.B).toBe(100);
+    });
+
+    it("lanza AppError 500 cuando falla query periodo A", async () => {
+      mockFromSequence([
+        { data: null, error: { message: "DB error" } },
+        { data: [], error: null },
+      ]);
+
+      await expect(
+        getInsights("user-123", "2026-02-01", "2026-02-07", "2026-02-08", "2026-02-15"),
+      ).rejects.toThrow(AppError);
+
+      mockFromSequence([
+        { data: null, error: { message: "DB error" } },
+        { data: [], error: null },
+      ]);
+
+      await expect(
+        getInsights("user-123", "2026-02-01", "2026-02-07", "2026-02-08", "2026-02-15"),
+      ).rejects.toMatchObject({ statusCode: 500 });
+    });
+
+    it("lanza AppError 500 cuando falla query periodo B", async () => {
+      mockFromSequence([
+        { data: [], error: null },
+        { data: null, error: { message: "DB error" } },
+      ]);
+
+      await expect(
+        getInsights("user-123", "2026-02-01", "2026-02-07", "2026-02-08", "2026-02-15"),
+      ).rejects.toThrow(AppError);
+
+      mockFromSequence([
+        { data: [], error: null },
+        { data: null, error: { message: "DB error" } },
+      ]);
+
+      await expect(
+        getInsights("user-123", "2026-02-01", "2026-02-07", "2026-02-08", "2026-02-15"),
+      ).rejects.toMatchObject({ statusCode: 500 });
+    });
+  });
+
+  describe("checkOverload", () => {
+    it("carga normal (<120%) retorna is_overloaded false, alert_level none", async () => {
+      const currentActivities = [makeActivity({ tss: 100 })];
+      // One activity per previous week, each with TSS 100 → avg = 100, percentage = 100%
+      const prevActivities = [
+        makeActivity({ tss: 100, date: dateInWeek(-1, 1) }),
+        makeActivity({ tss: 100, date: dateInWeek(-2, 1) }),
+        makeActivity({ tss: 100, date: dateInWeek(-3, 1) }),
+        makeActivity({ tss: 100, date: dateInWeek(-4, 1) }),
+      ];
+      mockFromSequence([
+        { data: currentActivities, error: null },
+        { data: prevActivities, error: null },
+      ]);
+
+      const result = await checkOverload("user-123");
+
+      expect(result.is_overloaded).toBe(false);
+      expect(result.alert_level).toBe("none");
+    });
+
+    it("warning (120-149%) retorna is_overloaded true, alert_level warning", async () => {
+      const currentActivities = [makeActivity({ tss: 260 })];
+      const prevActivities = [
+        makeActivity({ tss: 200, date: dateInWeek(-1, 1) }),
+        makeActivity({ tss: 200, date: dateInWeek(-2, 1) }),
+        makeActivity({ tss: 200, date: dateInWeek(-3, 1) }),
+        makeActivity({ tss: 200, date: dateInWeek(-4, 1) }),
+      ];
+      mockFromSequence([
+        { data: currentActivities, error: null },
+        { data: prevActivities, error: null },
+      ]);
+
+      const result = await checkOverload("user-123");
+
+      expect(result.is_overloaded).toBe(true);
+      expect(result.alert_level).toBe("warning");
+    });
+
+    it("critical (≥150%) retorna is_overloaded true, alert_level critical", async () => {
+      const currentActivities = [makeActivity({ tss: 300 })];
+      const prevActivities = [
+        makeActivity({ tss: 200, date: dateInWeek(-1, 1) }),
+        makeActivity({ tss: 200, date: dateInWeek(-2, 1) }),
+        makeActivity({ tss: 200, date: dateInWeek(-3, 1) }),
+        makeActivity({ tss: 200, date: dateInWeek(-4, 1) }),
+      ];
+      mockFromSequence([
+        { data: currentActivities, error: null },
+        { data: prevActivities, error: null },
+      ]);
+
+      const result = await checkOverload("user-123");
+
+      expect(result.is_overloaded).toBe(true);
+      expect(result.alert_level).toBe("critical");
+    });
+
+    it("sin actividades previas retorna percentage 0, is_overloaded false", async () => {
+      mockFromSequence([
+        { data: [makeActivity({ tss: 50 })], error: null },
+        { data: [], error: null },
+      ]);
+
+      const result = await checkOverload("user-123");
+
+      expect(result.percentage).toBe(0);
+      expect(result.is_overloaded).toBe(false);
+      expect(result.alert_level).toBe("none");
+    });
+
+    it("lanza AppError 500 cuando falla query", async () => {
+      mockFromSequence([
+        { data: null, error: { message: "DB error" } },
+        { data: [], error: null },
+      ]);
+
+      await expect(checkOverload("user-123")).rejects.toThrow(AppError);
+
+      mockFromSequence([
+        { data: null, error: { message: "DB error" } },
+        { data: [], error: null },
+      ]);
+
+      await expect(checkOverload("user-123")).rejects.toMatchObject({ statusCode: 500 });
+    });
+  });
+});

--- a/apps/api/src/services/insights.service.ts
+++ b/apps/api/src/services/insights.service.ts
@@ -1,0 +1,340 @@
+import type { ComparisonMetric, RadarDimension, InsightsAnalysis } from "shared";
+import { supabaseAdmin } from "./supabase.js";
+import { AppError } from "../plugins/error-handler.js";
+
+interface ActivityRow {
+  date: string;
+  duration_seconds: number;
+  distance_km: number | null;
+  avg_power_watts: number | null;
+  avg_hr_bpm: number | null;
+  tss: number | null;
+}
+
+interface PeriodMetrics {
+  distanceKm: number;
+  durationHours: number;
+  avgPower: number | null;
+  avgHR: number | null;
+  totalTSS: number;
+  sessionCount: number;
+}
+
+export interface InsightsResult {
+  comparison: ComparisonMetric[];
+  radar: RadarDimension[];
+  analysis: InsightsAnalysis | null;
+}
+
+export interface OverloadResult {
+  currentLoad: number;
+  avgLoad: number;
+  percentage: number;
+  is_overloaded: boolean;
+  alert_level: "none" | "warning" | "critical";
+}
+
+const ACTIVITY_SELECT = "date, duration_seconds, distance_km, avg_power_watts, avg_hr_bpm, tss";
+
+function calculatePeriodMetrics(activities: ActivityRow[]): PeriodMetrics {
+  const distanceKm =
+    Math.round(activities.reduce((sum, a) => sum + (a.distance_km ?? 0), 0) * 10) / 10;
+
+  const durationHours =
+    Math.round((activities.reduce((sum, a) => sum + a.duration_seconds, 0) / 3600) * 10) / 10;
+
+  const powerValues = activities
+    .map((a) => a.avg_power_watts)
+    .filter((v): v is number => v != null);
+  const avgPower =
+    powerValues.length > 0
+      ? Math.round(powerValues.reduce((sum, v) => sum + v, 0) / powerValues.length)
+      : null;
+
+  const hrValues = activities.map((a) => a.avg_hr_bpm).filter((v): v is number => v != null);
+  const avgHR =
+    hrValues.length > 0
+      ? Math.round(hrValues.reduce((sum, v) => sum + v, 0) / hrValues.length)
+      : null;
+
+  const totalTSS = activities.reduce((sum, a) => sum + (a.tss ?? 0), 0);
+
+  return {
+    distanceKm,
+    durationHours,
+    avgPower,
+    avgHR,
+    totalTSS,
+    sessionCount: activities.length,
+  };
+}
+
+function buildComparisonMetrics(a: PeriodMetrics, b: PeriodMetrics): ComparisonMetric[] {
+  return [
+    {
+      metric: "Distancia",
+      valueA: a.distanceKm,
+      valueB: b.distanceKm,
+      unit: "km",
+      color: "#3b82f6",
+    },
+    {
+      metric: "Tiempo",
+      valueA: a.durationHours,
+      valueB: b.durationHours,
+      unit: "h",
+      color: "#8b5cf6",
+    },
+    {
+      metric: "Potencia",
+      valueA: a.avgPower ?? 0,
+      valueB: b.avgPower ?? 0,
+      unit: "W",
+      color: "#f97316",
+    },
+    {
+      metric: "FC media",
+      valueA: a.avgHR ?? 0,
+      valueB: b.avgHR ?? 0,
+      unit: "bpm",
+      color: "#ef4444",
+      inverse: true,
+    },
+    { metric: "TSS", valueA: a.totalTSS, valueB: b.totalTSS, unit: "", color: "#eab308" },
+    {
+      metric: "Sesiones",
+      valueA: a.sessionCount,
+      valueB: b.sessionCount,
+      unit: "",
+      color: "#22c55e",
+    },
+  ];
+}
+
+function calculateRadarDimensions(a: PeriodMetrics, b: PeriodMetrics): RadarDimension[] {
+  const normalize = (value: number, cap: number) => Math.min(Math.round((value / cap) * 100), 100);
+
+  const volumenA = normalize(a.distanceKm, 200);
+  const volumenB = normalize(b.distanceKm, 200);
+
+  const intensidadA = normalize(a.avgPower ?? 0, 300);
+  const intensidadB = normalize(b.avgPower ?? 0, 300);
+
+  const consistenciaA = normalize(a.sessionCount, 7);
+  const consistenciaB = normalize(b.sessionCount, 7);
+
+  const tssPerSessionA = a.sessionCount > 0 ? a.totalTSS / a.sessionCount : 0;
+  const tssPerSessionB = b.sessionCount > 0 ? b.totalTSS / b.sessionCount : 0;
+  const recuperacionA = Math.max(0, Math.round(100 - (tssPerSessionA / 150) * 100));
+  const recuperacionB = Math.max(0, Math.round(100 - (tssPerSessionB / 150) * 100));
+
+  const powerDelta = (b.avgPower ?? 0) - (a.avgPower ?? 0);
+  const progresionA = 50;
+  const progresionB = Math.min(100, Math.max(0, Math.round(50 + powerDelta)));
+
+  return [
+    { metric: "Volumen", A: volumenA, B: volumenB },
+    { metric: "Intensidad", A: intensidadA, B: intensidadB },
+    { metric: "Consistencia", A: consistenciaA, B: consistenciaB },
+    { metric: "Recuperación", A: recuperacionA, B: recuperacionB },
+    { metric: "Progresión", A: progresionA, B: progresionB },
+  ];
+}
+
+function generateSimpleAnalysis(a: PeriodMetrics, b: PeriodMetrics): InsightsAnalysis | null {
+  if (a.sessionCount === 0 && b.sessionCount === 0) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  if (a.avgPower != null && b.avgPower != null && a.avgPower > 0) {
+    const powerChange = ((b.avgPower - a.avgPower) / a.avgPower) * 100;
+    if (Math.abs(powerChange) >= 1) {
+      parts.push(
+        powerChange > 0
+          ? `Tu potencia media ha subido un ${Math.abs(Math.round(powerChange))}%, lo que indica buena adaptación al entrenamiento.`
+          : `Tu potencia media ha bajado un ${Math.abs(Math.round(powerChange))}%. Puede ser fatiga acumulada o falta de intensidad.`,
+      );
+    }
+  }
+
+  if (a.distanceKm > 0) {
+    const distChange = ((b.distanceKm - a.distanceKm) / a.distanceKm) * 100;
+    if (Math.abs(distChange) >= 5) {
+      parts.push(
+        distChange > 0
+          ? `Has aumentado el volumen un ${Math.abs(Math.round(distChange))}% respecto a la semana anterior.`
+          : `El volumen ha disminuido un ${Math.abs(Math.round(distChange))}% esta semana.`,
+      );
+    }
+  }
+
+  const summary =
+    parts.length > 0
+      ? parts.join(" ")
+      : `Has completado ${b.sessionCount} sesión${b.sessionCount !== 1 ? "es" : ""} esta semana.`;
+
+  let alert: string | undefined;
+  if (a.totalTSS > 0) {
+    const tssChange = ((b.totalTSS - a.totalTSS) / a.totalTSS) * 100;
+    if (tssChange > 15) {
+      alert = `Tu carga de entrenamiento (TSS) ha aumentado un ${Math.round(tssChange)}%. Vigila la recuperación para evitar sobreentrenamiento.`;
+    }
+  }
+
+  let recommendation: string;
+  if (b.sessionCount === 0) {
+    recommendation =
+      "No tienes sesiones registradas esta semana. Intenta mantener al menos 3 entrenamientos semanales para sostener tu forma.";
+  } else if (b.sessionCount < 3) {
+    recommendation =
+      "Intenta añadir una sesión más esta semana para mejorar la consistencia. La regularidad es clave para el progreso.";
+  } else {
+    recommendation =
+      "Buen ritmo de entrenamiento. Mantén la alternancia entre sesiones intensas y de recuperación para optimizar las adaptaciones.";
+  }
+
+  return { summary, alert, recommendation };
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  d.setDate(diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export async function getInsights(
+  userId: string,
+  periodAStart: string,
+  periodAEnd: string,
+  periodBStart: string,
+  periodBEnd: string,
+): Promise<InsightsResult> {
+  const [resultA, resultB] = await Promise.all([
+    supabaseAdmin
+      .from("activities")
+      .select(ACTIVITY_SELECT)
+      .eq("user_id", userId)
+      .gte("date", periodAStart)
+      .lte("date", periodAEnd),
+    supabaseAdmin
+      .from("activities")
+      .select(ACTIVITY_SELECT)
+      .eq("user_id", userId)
+      .gte("date", periodBStart)
+      .lte("date", periodBEnd),
+  ]);
+
+  if (resultA.error) {
+    throw new AppError(
+      `Failed to fetch period A activities: ${resultA.error.message}`,
+      500,
+      "DATABASE_ERROR",
+    );
+  }
+
+  if (resultB.error) {
+    throw new AppError(
+      `Failed to fetch period B activities: ${resultB.error.message}`,
+      500,
+      "DATABASE_ERROR",
+    );
+  }
+
+  const activitiesA = (resultA.data ?? []) as ActivityRow[];
+  const activitiesB = (resultB.data ?? []) as ActivityRow[];
+
+  const metricsA = calculatePeriodMetrics(activitiesA);
+  const metricsB = calculatePeriodMetrics(activitiesB);
+
+  const comparison = buildComparisonMetrics(metricsA, metricsB);
+  const radar = calculateRadarDimensions(metricsA, metricsB);
+  const analysis = generateSimpleAnalysis(metricsA, metricsB);
+
+  return { comparison, radar, analysis };
+}
+
+export async function checkOverload(userId: string): Promise<OverloadResult> {
+  const now = new Date();
+  const weekStart = getWeekStart(now);
+  const weekStartStr = weekStart.toISOString().split("T")[0];
+
+  const fourWeeksAgo = new Date(weekStart);
+  fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+  const fourWeeksAgoStr = fourWeeksAgo.toISOString().split("T")[0];
+
+  const yesterdayOfWeekStart = new Date(weekStart);
+  yesterdayOfWeekStart.setDate(yesterdayOfWeekStart.getDate() - 1);
+  const yesterdayStr = yesterdayOfWeekStart.toISOString().split("T")[0];
+
+  const [currentResult, prevResult] = await Promise.all([
+    supabaseAdmin
+      .from("activities")
+      .select(ACTIVITY_SELECT)
+      .eq("user_id", userId)
+      .gte("date", weekStartStr),
+    supabaseAdmin
+      .from("activities")
+      .select(ACTIVITY_SELECT)
+      .eq("user_id", userId)
+      .gte("date", fourWeeksAgoStr)
+      .lte("date", yesterdayStr),
+  ]);
+
+  if (currentResult.error) {
+    throw new AppError(
+      `Failed to fetch current week activities: ${currentResult.error.message}`,
+      500,
+      "DATABASE_ERROR",
+    );
+  }
+
+  if (prevResult.error) {
+    throw new AppError(
+      `Failed to fetch previous activities: ${prevResult.error.message}`,
+      500,
+      "DATABASE_ERROR",
+    );
+  }
+
+  const currentActivities = (currentResult.data ?? []) as ActivityRow[];
+  const prevActivities = (prevResult.data ?? []) as ActivityRow[];
+
+  const currentLoad = currentActivities.reduce((sum, a) => sum + (a.tss ?? 0), 0);
+
+  // Calculate TSS per week for the 4 previous weeks
+  const weekLoads: number[] = [];
+  for (let i = 1; i <= 4; i++) {
+    const wStart = new Date(weekStart);
+    wStart.setDate(wStart.getDate() - 7 * i);
+    const wEnd = new Date(wStart);
+    wEnd.setDate(wEnd.getDate() + 7);
+
+    const load = prevActivities
+      .filter((a) => {
+        const d = new Date(a.date);
+        return d >= wStart && d < wEnd;
+      })
+      .reduce((sum, a) => sum + (a.tss ?? 0), 0);
+
+    weekLoads.push(load);
+  }
+
+  const avgLoad =
+    weekLoads.length > 0 ? Math.round(weekLoads.reduce((s, v) => s + v, 0) / weekLoads.length) : 0;
+
+  if (avgLoad === 0) {
+    return { currentLoad, avgLoad: 0, percentage: 0, is_overloaded: false, alert_level: "none" };
+  }
+
+  const percentage = Math.round((currentLoad / avgLoad) * 100);
+  const is_overloaded = percentage >= 120;
+  const alert_level: OverloadResult["alert_level"] =
+    percentage >= 150 ? "critical" : percentage >= 120 ? "warning" : "none";
+
+  return { currentLoad, avgLoad, percentage, is_overloaded, alert_level };
+}

--- a/apps/api/src/services/profile.service.test.ts
+++ b/apps/api/src/services/profile.service.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppError } from "../plugins/error-handler.js";
+
+const mockSingle = vi.fn();
+
+vi.mock("./supabase.js", () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: mockSingle,
+        })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: mockSingle,
+          })),
+        })),
+      })),
+    })),
+  },
+}));
+
+// Import after mock
+const { getProfile, updateProfile } = await import("./profile.service.js");
+
+const mockProfile = {
+  id: "user-123",
+  email: "test@example.com",
+  display_name: "Test User",
+  age: 42,
+  weight_kg: 75.5,
+  ftp: 250,
+  max_hr: 185,
+  rest_hr: 55,
+  goal: "performance",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("ProfileService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getProfile", () => {
+    it("devuelve perfil cuando existe", async () => {
+      mockSingle.mockResolvedValue({ data: mockProfile, error: null });
+      const result = await getProfile("user-123");
+      expect(result).toEqual(mockProfile);
+    });
+
+    it("lanza AppError 404 cuando hay error de Supabase", async () => {
+      mockSingle.mockResolvedValue({ data: null, error: { message: "Not found" } });
+      await expect(getProfile("user-123")).rejects.toThrow(AppError);
+      await expect(getProfile("user-123")).rejects.toMatchObject({
+        statusCode: 404,
+        code: "NOT_FOUND",
+      });
+    });
+
+    it("lanza AppError 404 cuando data es null", async () => {
+      mockSingle.mockResolvedValue({ data: null, error: null });
+      await expect(getProfile("user-123")).rejects.toThrow(AppError);
+      await expect(getProfile("user-123")).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe("updateProfile", () => {
+    it("actualiza perfil con datos válidos", async () => {
+      const updated = { ...mockProfile, display_name: "Updated Name" };
+      mockSingle.mockResolvedValue({ data: updated, error: null });
+      const result = await updateProfile("user-123", { display_name: "Updated Name" });
+      expect(result).toEqual(updated);
+    });
+
+    it("lanza AppError 404 cuando el usuario no existe", async () => {
+      mockSingle.mockResolvedValue({ data: null, error: { message: "Not found" } });
+      await expect(updateProfile("user-123", { display_name: "Test" })).rejects.toThrow(AppError);
+      await expect(updateProfile("user-123", { display_name: "Test" })).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+
+    it("lanza error cuando age es negativa", async () => {
+      await expect(updateProfile("user-123", { age: -5 })).rejects.toThrow();
+    });
+
+    it("lanza error cuando goal es inválido", async () => {
+      await expect(
+        updateProfile("user-123", { goal: "invalid" as "performance" }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "vitest.config.ts"]
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ["node_modules", "dist"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@types/node@22.19.11)(jiti@1.21.7)(jsdom@28.0.0)(tsx@4.21.0)
 
   apps/web:
     dependencies:


### PR DESCRIPTION
## Summary
- Implementa el **Bloque 3 de Fase 3**: mueve los cálculos de insights del frontend al backend API
- Crea `GET /api/v1/insights` (comparación entre dos periodos: métricas, radar, análisis) y `GET /api/v1/insights/overload-check` (detección de sobrecarga semanal)
- Configura Vitest para `apps/api` y restaura los test files en `src/` (estaban solo en `dist/`)

## Cambios principales

### Nuevos archivos
| Archivo | Descripción |
|---------|-------------|
| `services/insights.service.ts` | Lógica de negocio: `getInsights()` y `checkOverload()` — replica cálculos del frontend |
| `routes/insights.ts` | 2 endpoints GET con validación de query params |
| `services/insights.service.test.ts` | 15 tests unitarios (10 getInsights + 5 checkOverload) |
| `routes/routes.integration.test.ts` | 15 tests integración (4 nuevos de insights + 11 existentes restaurados) |
| `vitest.config.ts` | Configuración de Vitest para el API |
| `*.test.ts` (3 archivos) | Tests pre-existentes restaurados en `src/` (solo estaban en `dist/`) |

### Archivos modificados
| Archivo | Cambio |
|---------|--------|
| `app.ts` | +2 líneas: import y register de `insightsRoutes` |
| `package.json` | +scripts `test`/`test:watch`, +vitest devDep |
| `tsconfig.json` | Excluir `*.test.ts` del build |
| `error-handler.ts` | Envolver con `fastify-plugin` (fix scoping del error handler) |

## Test plan
- [x] `pnpm --filter api test` → 65 tests pasan (5 archivos)
- [x] `pnpm test` → 168 tests monorepo (71 web + 32 shared + 65 api)
- [x] `pnpm --filter api typecheck` → sin errores
- [x] `pnpm --filter api build` → sin errores, sin test files en dist/
- [x] `pnpm lint` → sin errores
- [x] `pnpm format:check` → formateado