### PR TITLE
feat: reglas de entrenamiento y cálculos (Bloque 4)

### DIFF
--- a/docs/specs/L2-backend-04-training-rules.md
+++ b/docs/specs/L2-backend-04-training-rules.md
@@ -1,0 +1,372 @@
+# L2 — Diseño Técnico: Reglas de Entrenamiento (Bloque 4)
+
+> **Tipo**: Especificación técnica (L2)
+> **Fase**: 3 — Backend + IA
+> **Bloque**: 4 — Reglas de Entrenamiento
+> **Estado**: 🔲 Pendiente
+> **Fecha**: 2026-02-15
+
+---
+
+## 1. Objetivo
+
+Implementar heurísticas de entrenamiento codificadas en TypeScript dentro de `packages/shared`, reutilizables tanto por el backend (endpoints de IA, insights) como por el frontend. Estas reglas NO dependen de la IA — son cálculos determinísticos.
+
+**Funciones a implementar**:
+- Cálculos de entrenamiento: TSS, IF, CTL, ATL, TSB
+- Reglas de alerta: sobrecarga, descanso urgente, progresión excesiva
+- Extensión de zonas: clasificación de actividad por zona dominante
+
+**Consumidores**:
+- `apps/api/src/services/insights.service.ts` — ya calcula TSS/overload inline, se refactorizará
+- `apps/api/src/services/activity.service.ts` — ya calcula TSS en create, se refactorizará
+- Bloque 5 (IA) — prompts reciben estos cálculos como contexto
+- Frontend — puede usar directamente para UI (TSB gauge, alertas)
+
+---
+
+## 2. Archivos a Crear/Modificar
+
+| Archivo | Acción | Descripción |
+|---------|--------|-------------|
+| `packages/shared/src/utils/training-calculations.ts` | **Crear** | Funciones puras: TSS, IF, CTL, ATL, TSB |
+| `packages/shared/src/utils/training-calculations.test.ts` | **Crear** | Tests unitarios (~15 tests) |
+| `packages/shared/src/utils/training-rules.ts` | **Crear** | Reglas de alerta basadas en los cálculos |
+| `packages/shared/src/utils/training-rules.test.ts` | **Crear** | Tests unitarios (~10 tests) |
+| `packages/shared/src/index.ts` | **Modificar** | Re-exportar nuevas funciones y tipos |
+
+---
+
+## 3. Cálculos de Entrenamiento (`training-calculations.ts`)
+
+### 3.1 Tipos
+
+```typescript
+/** Entrada mínima de actividad para cálculos */
+export interface ActivityInput {
+  date: string;                    // YYYY-MM-DD
+  duration_seconds: number;
+  avg_power_watts: number | null;
+  tss: number | null;
+}
+
+/** Resultado del cálculo de forma/fatiga */
+export interface TrainingLoad {
+  ctl: number;    // Chronic Training Load (fitness) — media 42 días
+  atl: number;    // Acute Training Load (fatigue) — media 7 días
+  tsb: number;    // Training Stress Balance (form) — CTL - ATL
+}
+```
+
+### 3.2 Funciones
+
+#### `calculateIF(avgPower, ftp): number`
+
+**Intensity Factor**: ratio entre potencia media y FTP.
+
+```
+IF = avg_power / ftp
+```
+
+- Retorna 0 si `avgPower` o `ftp` son null/0
+- No tiene unidades, típicamente entre 0.5 y 1.3
+
+#### `calculateTSS(avgPower, ftp, durationSeconds): number`
+
+**Training Stress Score**: medida de carga de una sesión.
+
+```
+IF = avg_power / ftp
+TSS = IF² × (duration_seconds / 3600) × 100
+```
+
+- Retorna 0 si `avgPower` o `ftp` son null/0
+- Resultado redondeado a entero (`Math.round`)
+- Fórmula idéntica a la ya implementada en `activity.service.ts:101-107`
+
+#### `calculateCTL(activities, targetDate): number`
+
+**Chronic Training Load (Fitness)**: media exponencial ponderada de TSS con constante de 42 días.
+
+```
+CTL_hoy = CTL_ayer + (TSS_hoy - CTL_ayer) / 42
+```
+
+- `activities`: array ordenado por fecha (más antigua primero)
+- `targetDate`: fecha hasta la cual calcular (inclusive)
+- Itera día a día desde la primera actividad hasta `targetDate`
+- Días sin actividad: TSS = 0
+- Resultado redondeado a 1 decimal
+
+#### `calculateATL(activities, targetDate): number`
+
+**Acute Training Load (Fatigue)**: media exponencial ponderada de TSS con constante de 7 días.
+
+```
+ATL_hoy = ATL_ayer + (TSS_hoy - ATL_ayer) / 7
+```
+
+- Misma mecánica que CTL pero con ventana de 7 días
+- Resultado redondeado a 1 decimal
+
+#### `calculateTrainingLoad(activities, targetDate): TrainingLoad`
+
+**Función principal** que devuelve CTL, ATL y TSB en una sola llamada.
+
+```
+TSB = CTL - ATL
+```
+
+- TSB positivo → buena forma, listo para competir
+- TSB negativo → fatiga acumulada, necesita recuperación
+- TSB muy negativo (< -30) → riesgo de sobreentrenamiento
+
+#### `calculateWeeklyTSS(activities, weekStartDate): number`
+
+Suma de TSS de actividades en una semana (lunes a domingo).
+
+- Útil para cálculos de overload existentes en `insights.service.ts`
+
+---
+
+## 4. Reglas de Alerta (`training-rules.ts`)
+
+### 4.1 Tipos
+
+```typescript
+export type AlertLevel = "none" | "warning" | "critical";
+
+export interface TrainingAlert {
+  type: "overload" | "rest_needed" | "detraining" | "ramp_rate";
+  level: AlertLevel;
+  message: string;
+}
+```
+
+### 4.2 Reglas
+
+#### `checkOverloadAlert(weeklyTSS, avgWeeklyTSS): TrainingAlert`
+
+Alerta de sobrecarga semanal (ya implementada inline en `insights.service.ts`).
+
+| Condición | Level | Tipo |
+|-----------|-------|------|
+| `weeklyTSS >= 1.5 × avg` | `critical` | `overload` |
+| `weeklyTSS >= 1.2 × avg` | `warning` | `overload` |
+| Otherwise | `none` | `overload` |
+
+Si `avgWeeklyTSS === 0`: siempre retorna `"none"`.
+
+#### `checkRestAlert(recentActivities): TrainingAlert`
+
+Alerta de descanso urgente: 3+ días consecutivos de intensidad alta.
+
+**Criterio de "intensidad alta"**:
+- `tss >= 80` para una sesión individual, O
+- `rpe >= 8` si disponible
+
+| Condición | Level | Tipo |
+|-----------|-------|------|
+| 4+ días consecutivos intensos | `critical` | `rest_needed` |
+| 3 días consecutivos intensos | `warning` | `rest_needed` |
+| Otherwise | `none` | `rest_needed` |
+
+#### `checkDetrainingAlert(tsb, lastActivityDate, today): TrainingAlert`
+
+Alerta de pérdida de forma.
+
+| Condición | Level | Tipo |
+|-----------|-------|------|
+| Sin actividad en 10+ días | `critical` | `detraining` |
+| Sin actividad en 7+ días | `warning` | `detraining` |
+| TSB > 25 (demasiado descanso) | `warning` | `detraining` |
+| Otherwise | `none` | `detraining` |
+
+#### `checkRampRateAlert(ctlCurrent, ctlPrevWeek): TrainingAlert`
+
+Alerta de progresión excesiva: incremento de CTL > 7 puntos/semana.
+
+| Condición | Level | Tipo |
+|-----------|-------|------|
+| CTL delta > 10/semana | `critical` | `ramp_rate` |
+| CTL delta > 7/semana | `warning` | `ramp_rate` |
+| Otherwise | `none` | `ramp_rate` |
+
+#### `evaluateTrainingAlerts(params): TrainingAlert[]`
+
+**Función principal** que ejecuta todas las reglas y retorna solo las alertas con `level !== "none"`.
+
+```typescript
+interface AlertParams {
+  weeklyTSS: number;
+  avgWeeklyTSS: number;
+  recentActivities: Array<{ date: string; tss: number | null; rpe: number | null }>;
+  trainingLoad: TrainingLoad;
+  ctlPreviousWeek: number;
+  lastActivityDate: string | null;
+  today: string;
+}
+```
+
+---
+
+## 5. Extensión de Zonas
+
+### 5.1 `classifyActivityZone(avgPower, ftp): string`
+
+Determina la zona dominante de una actividad basándose en potencia media vs FTP.
+
+Utiliza `POWER_ZONES` de `constants/zones.ts` existente:
+
+```typescript
+function classifyActivityZone(avgPower: number | null, ftp: number | null): string | null {
+  if (!avgPower || !ftp) return null;
+  const ratio = avgPower / ftp;
+  // Buscar en POWER_ZONES la zona donde minPct <= ratio <= maxPct
+  const zone = POWER_ZONES.find(z => ratio >= z.minPct && ratio <= z.maxPct);
+  return zone?.zone ?? null;
+}
+```
+
+No se crea archivo nuevo — se añade a `training-calculations.ts` ya que es una función de cálculo.
+
+---
+
+## 6. Exports desde `packages/shared/src/index.ts`
+
+```typescript
+// Training calculations
+export {
+  calculateIF,
+  calculateTSS,
+  calculateCTL,
+  calculateATL,
+  calculateTrainingLoad,
+  calculateWeeklyTSS,
+  classifyActivityZone,
+  type ActivityInput as TrainingActivityInput,
+  type TrainingLoad,
+} from "./utils/training-calculations";
+
+// Training rules
+export {
+  checkOverloadAlert,
+  checkRestAlert,
+  checkDetrainingAlert,
+  checkRampRateAlert,
+  evaluateTrainingAlerts,
+  type AlertLevel,
+  type TrainingAlert,
+} from "./utils/training-rules";
+```
+
+---
+
+## 7. Testing
+
+### 7.1 `training-calculations.test.ts` (~15 tests)
+
+**calculateIF**:
+1. IF correcto para 200W / 250W FTP → 0.8
+2. IF = 0 cuando avgPower es null
+3. IF = 0 cuando ftp es 0
+
+**calculateTSS**:
+4. TSS correcto: 200W, 250W FTP, 1h → 64
+5. TSS correcto: 300W, 250W FTP, 1.5h → 216
+6. TSS = 0 cuando avgPower es null
+7. TSS redondeado a entero
+
+**calculateCTL/ATL**:
+8. CTL con 42 días de TSS=100 → converge cerca de 100
+9. ATL con 7 días de TSS=100 → converge más rápido que CTL
+10. ATL > CTL cuando hay carga reciente alta (fatiga > fitness)
+11. Días sin actividad: TSS cuenta como 0
+
+**calculateTrainingLoad**:
+12. TSB positivo tras semana de descanso
+13. TSB negativo tras semana intensa
+14. Sin actividades → todo en 0
+
+**calculateWeeklyTSS**:
+15. Suma correcta de TSS en una semana
+
+### 7.2 `training-rules.test.ts` (~10 tests)
+
+**checkOverloadAlert**:
+1. `none` cuando TSS semanal < 120% del promedio
+2. `warning` cuando TSS semanal entre 120-149%
+3. `critical` cuando TSS semanal ≥ 150%
+4. `none` cuando avgWeeklyTSS = 0
+
+**checkRestAlert**:
+5. `warning` con 3 días consecutivos de TSS ≥ 80
+6. `critical` con 4+ días consecutivos
+7. `none` con 2 días consecutivos
+
+**checkDetrainingAlert**:
+8. `warning` sin actividad en 7+ días
+9. `critical` sin actividad en 10+ días
+
+**checkRampRateAlert**:
+10. `warning` cuando CTL sube > 7 puntos/semana
+
+---
+
+## 8. Refactoring Futuro (No incluido en Bloque 4)
+
+Tras implementar estas funciones puras en `shared`, el siguiente paso será:
+- Refactorizar `activity.service.ts` para usar `calculateTSS()` de shared
+- Refactorizar `insights.service.ts:checkOverload()` para usar `checkOverloadAlert()` de shared
+- Ambos refactorings se harán cuando se migre el frontend (Bloque 8), para evitar cambios innecesarios ahora
+
+---
+
+## 9. Decisiones Técnicas (ADRs)
+
+### ADR-010: Funciones puras en `packages/shared`
+
+**Decisión**: Todas las funciones de cálculo son puras (sin side effects, sin I/O).
+
+**Rationale**:
+- Testeable sin mocks
+- Reutilizable en backend y frontend
+- La IA recibe estos cálculos como contexto precalculado, no los recalcula
+
+### ADR-011: Media exponencial para CTL/ATL
+
+**Decisión**: Usar EMA (Exponential Moving Average) estándar de ciclismo.
+
+**Rationale**:
+- CTL (42 días) y ATL (7 días) son estándares de la industria (TrainingPeaks, WKO5)
+- Fórmula bien documentada y comprensible para ciclistas
+- No requiere almacenar histórico completo — se puede calcular incrementalmente
+
+### ADR-012: Alertas como funciones independientes
+
+**Decisión**: Cada tipo de alerta es una función separada + una función agregadora.
+
+**Rationale**:
+- Testeable individualmente
+- Extensible: añadir nuevas reglas sin modificar las existentes
+- La función agregadora filtra y devuelve solo alertas activas
+
+---
+
+## 10. Criterios de Aceptación
+
+- [ ] `calculateIF()` retorna ratio correcto avgPower/FTP
+- [ ] `calculateTSS()` coincide con fórmula estándar IF² × hours × 100
+- [ ] `calculateCTL()` converge correctamente con constante de 42 días
+- [ ] `calculateATL()` converge correctamente con constante de 7 días
+- [ ] `calculateTrainingLoad()` retorna CTL, ATL, TSB consistentes
+- [ ] `checkOverloadAlert()` detecta sobrecarga en umbrales 120%/150%
+- [ ] `checkRestAlert()` detecta 3+ días intensos consecutivos
+- [ ] `checkDetrainingAlert()` detecta inactividad prolongada
+- [ ] `checkRampRateAlert()` detecta progresión excesiva > 7 CTL/semana
+- [ ] `evaluateTrainingAlerts()` agrega todas las alertas activas
+- [ ] `classifyActivityZone()` clasifica zona correcta según power/FTP
+- [ ] Todos los exports correctos desde `packages/shared/src/index.ts`
+- [ ] ~25 tests pasando en `packages/shared`
+- [ ] `pnpm typecheck` sin errores
+- [ ] `pnpm lint` sin errores

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -50,3 +50,28 @@ export {
   type RadarDimension,
   type InsightsAnalysis,
 } from "./schemas/insights";
+
+// Training calculations
+export {
+  calculateIF,
+  calculateTSS,
+  calculateCTL,
+  calculateATL,
+  calculateTrainingLoad,
+  calculateWeeklyTSS,
+  classifyActivityZone,
+  type TrainingActivityInput,
+  type TrainingLoad,
+} from "./utils/training-calculations";
+
+// Training rules
+export {
+  checkOverloadAlert,
+  checkRestAlert,
+  checkDetrainingAlert,
+  checkRampRateAlert,
+  evaluateTrainingAlerts,
+  type AlertLevel,
+  type TrainingAlert,
+  type AlertParams,
+} from "./utils/training-rules";

--- a/packages/shared/src/utils/training-calculations.test.ts
+++ b/packages/shared/src/utils/training-calculations.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateIF,
+  calculateTSS,
+  calculateCTL,
+  calculateATL,
+  calculateTrainingLoad,
+  calculateWeeklyTSS,
+  classifyActivityZone,
+} from "./training-calculations";
+import type { TrainingActivityInput } from "./training-calculations";
+
+describe("training-calculations", () => {
+  describe("calculateIF", () => {
+    it("calcula IF correcto para 200W / 250W FTP", () => {
+      expect(calculateIF(200, 250)).toBeCloseTo(0.8);
+    });
+
+    it("retorna 0 cuando avgPower es null", () => {
+      expect(calculateIF(null, 250)).toBe(0);
+    });
+
+    it("retorna 0 cuando ftp es 0", () => {
+      expect(calculateIF(200, 0)).toBe(0);
+    });
+
+    it("retorna 0 cuando ftp es null", () => {
+      expect(calculateIF(200, null)).toBe(0);
+    });
+  });
+
+  describe("calculateTSS", () => {
+    it("calcula TSS correcto: 200W, 250W FTP, 1h → 64", () => {
+      expect(calculateTSS(200, 250, 3600)).toBe(64);
+    });
+
+    it("calcula TSS correcto: 300W, 250W FTP, 1.5h → 216", () => {
+      // IF = 300/250 = 1.2, IF² = 1.44, TSS = 1.44 * 1.5 * 100 = 216
+      expect(calculateTSS(300, 250, 5400)).toBe(216);
+    });
+
+    it("retorna 0 cuando avgPower es null", () => {
+      expect(calculateTSS(null, 250, 3600)).toBe(0);
+    });
+
+    it("retorna resultado redondeado a entero", () => {
+      // IF = 180/250 = 0.72, IF² = 0.5184, TSS = 0.5184 * 1 * 100 = 51.84 → 52
+      expect(calculateTSS(180, 250, 3600)).toBe(52);
+    });
+  });
+
+  describe("calculateCTL", () => {
+    it("converge cerca de 100 tras 42+ días de TSS=100 diario", () => {
+      const activities: TrainingActivityInput[] = [];
+      for (let i = 0; i < 60; i++) {
+        const date = new Date("2026-01-01");
+        date.setDate(date.getDate() + i);
+        activities.push({
+          date: date.toISOString().slice(0, 10),
+          duration_seconds: 3600,
+          avg_power_watts: 200,
+          tss: 100,
+        });
+      }
+      const ctl = calculateCTL(activities, "2026-03-01");
+      // After 60 days of TSS=100, CTL should be close to 100
+      expect(ctl).toBeGreaterThan(70);
+      expect(ctl).toBeLessThanOrEqual(100);
+    });
+
+    it("retorna 0 sin actividades", () => {
+      expect(calculateCTL([], "2026-02-15")).toBe(0);
+    });
+
+    it("días sin actividad cuentan como TSS=0", () => {
+      const activities: TrainingActivityInput[] = [
+        { date: "2026-02-01", duration_seconds: 3600, avg_power_watts: 200, tss: 100 },
+        // gap de varios días
+        { date: "2026-02-10", duration_seconds: 3600, avg_power_watts: 200, tss: 100 },
+      ];
+      const ctl = calculateCTL(activities, "2026-02-10");
+      // Should be low because of the gap
+      expect(ctl).toBeLessThan(20);
+    });
+  });
+
+  describe("calculateATL", () => {
+    it("converge más rápido que CTL (constante 7 vs 42)", () => {
+      const activities: TrainingActivityInput[] = [];
+      for (let i = 0; i < 14; i++) {
+        const date = new Date("2026-02-01");
+        date.setDate(date.getDate() + i);
+        activities.push({
+          date: date.toISOString().slice(0, 10),
+          duration_seconds: 3600,
+          avg_power_watts: 200,
+          tss: 100,
+        });
+      }
+      const targetDate = "2026-02-14";
+      const atl = calculateATL(activities, targetDate);
+      const ctl = calculateCTL(activities, targetDate);
+      // ATL should converge faster
+      expect(atl).toBeGreaterThan(ctl);
+    });
+
+    it("ATL > CTL con carga reciente alta indica fatiga", () => {
+      const activities: TrainingActivityInput[] = [];
+      // 7 días de TSS=200 (alto)
+      for (let i = 0; i < 7; i++) {
+        const date = new Date("2026-02-08");
+        date.setDate(date.getDate() + i);
+        activities.push({
+          date: date.toISOString().slice(0, 10),
+          duration_seconds: 3600,
+          avg_power_watts: 300,
+          tss: 200,
+        });
+      }
+      const load = calculateTrainingLoad(activities, "2026-02-14");
+      expect(load.atl).toBeGreaterThan(load.ctl);
+      expect(load.tsb).toBeLessThan(0);
+    });
+  });
+
+  describe("calculateTrainingLoad", () => {
+    it("TSB positivo tras semana de descanso después de entrenamiento", () => {
+      const activities: TrainingActivityInput[] = [];
+      // 3 semanas de entrenamiento
+      for (let i = 0; i < 21; i++) {
+        const date = new Date("2026-01-10");
+        date.setDate(date.getDate() + i);
+        activities.push({
+          date: date.toISOString().slice(0, 10),
+          duration_seconds: 3600,
+          avg_power_watts: 200,
+          tss: 80,
+        });
+      }
+      // Luego 7 días de descanso (sin actividad)
+      const afterRest = "2026-02-07";
+      const load = calculateTrainingLoad(activities, afterRest);
+      // CTL cae lentamente, ATL cae rápidamente → TSB se vuelve positivo
+      expect(load.tsb).toBeGreaterThan(0);
+    });
+
+    it("TSB negativo tras semana intensa", () => {
+      const activities: TrainingActivityInput[] = [];
+      for (let i = 0; i < 7; i++) {
+        const date = new Date("2026-02-01");
+        date.setDate(date.getDate() + i);
+        activities.push({
+          date: date.toISOString().slice(0, 10),
+          duration_seconds: 3600,
+          avg_power_watts: 300,
+          tss: 150,
+        });
+      }
+      const load = calculateTrainingLoad(activities, "2026-02-07");
+      expect(load.tsb).toBeLessThan(0);
+    });
+
+    it("sin actividades → todo en 0", () => {
+      const load = calculateTrainingLoad([], "2026-02-15");
+      expect(load.ctl).toBe(0);
+      expect(load.atl).toBe(0);
+      expect(load.tsb).toBe(0);
+    });
+  });
+
+  describe("calculateWeeklyTSS", () => {
+    it("suma correcta de TSS en una semana", () => {
+      const activities: TrainingActivityInput[] = [
+        { date: "2026-02-09", duration_seconds: 3600, avg_power_watts: 200, tss: 60 },
+        { date: "2026-02-10", duration_seconds: 3600, avg_power_watts: 200, tss: 80 },
+        { date: "2026-02-12", duration_seconds: 3600, avg_power_watts: 200, tss: 50 },
+        // Fuera de la semana
+        { date: "2026-02-16", duration_seconds: 3600, avg_power_watts: 200, tss: 100 },
+      ];
+      // Semana del 9 al 15 de febrero
+      expect(calculateWeeklyTSS(activities, "2026-02-09")).toBe(190);
+    });
+
+    it("ignora actividades con tss null", () => {
+      const activities: TrainingActivityInput[] = [
+        { date: "2026-02-09", duration_seconds: 3600, avg_power_watts: null, tss: null },
+        { date: "2026-02-10", duration_seconds: 3600, avg_power_watts: 200, tss: 80 },
+      ];
+      expect(calculateWeeklyTSS(activities, "2026-02-09")).toBe(80);
+    });
+  });
+
+  describe("classifyActivityZone", () => {
+    it("clasifica Z1 (recuperación) para potencia baja", () => {
+      // 100W con FTP 250 → ratio 0.4 → Z1 (0-0.56)
+      expect(classifyActivityZone(100, 250)).toBe("Z1");
+    });
+
+    it("clasifica Z2 (resistencia) para ratio ~0.7", () => {
+      // 175W con FTP 250 → ratio 0.7 → Z2 (0.56-0.75)
+      expect(classifyActivityZone(175, 250)).toBe("Z2");
+    });
+
+    it("clasifica Z4 (umbral) para ratio ~1.0", () => {
+      // 250W con FTP 250 → ratio 1.0 → Z4 (0.91-1.05)
+      expect(classifyActivityZone(250, 250)).toBe("Z4");
+    });
+
+    it("clasifica Z6 (anaeróbico) para ratio > 1.2", () => {
+      // 350W con FTP 250 → ratio 1.4 → Z6 (>1.2)
+      expect(classifyActivityZone(350, 250)).toBe("Z6");
+    });
+
+    it("retorna null cuando avgPower es null", () => {
+      expect(classifyActivityZone(null, 250)).toBeNull();
+    });
+
+    it("retorna null cuando ftp es null", () => {
+      expect(classifyActivityZone(200, null)).toBeNull();
+    });
+  });
+});

--- a/packages/shared/src/utils/training-calculations.ts
+++ b/packages/shared/src/utils/training-calculations.ts
@@ -1,0 +1,163 @@
+import { POWER_ZONES } from "../constants/zones";
+
+/** Entrada mínima de actividad para cálculos de carga */
+export interface TrainingActivityInput {
+  date: string;
+  duration_seconds: number;
+  avg_power_watts: number | null;
+  tss: number | null;
+}
+
+/** Resultado del cálculo de forma/fatiga */
+export interface TrainingLoad {
+  ctl: number;
+  atl: number;
+  tsb: number;
+}
+
+/**
+ * Intensity Factor: ratio entre potencia media y FTP.
+ * Típicamente entre 0.5 (recuperación) y 1.3 (sprint).
+ */
+export function calculateIF(avgPower: number | null, ftp: number | null): number {
+  if (!avgPower || !ftp) return 0;
+  return avgPower / ftp;
+}
+
+/**
+ * Training Stress Score: medida de carga de una sesión.
+ * TSS = IF² × duration_hours × 100
+ */
+export function calculateTSS(
+  avgPower: number | null,
+  ftp: number | null,
+  durationSeconds: number,
+): number {
+  const intensityFactor = calculateIF(avgPower, ftp);
+  if (intensityFactor === 0) return 0;
+  const durationHours = durationSeconds / 3600;
+  return Math.round(intensityFactor * intensityFactor * durationHours * 100);
+}
+
+/**
+ * Agrupa TSS por día (YYYY-MM-DD) para cálculos de EMA.
+ * Si hay múltiples actividades en un día, suma el TSS.
+ */
+function buildDailyTSSMap(activities: TrainingActivityInput[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const a of activities) {
+    const day = a.date.slice(0, 10);
+    map.set(day, (map.get(day) ?? 0) + (a.tss ?? 0));
+  }
+  return map;
+}
+
+/**
+ * Genera array de días entre start y end (inclusive), formato YYYY-MM-DD.
+ */
+function dayRange(start: Date, end: Date): string[] {
+  const days: string[] = [];
+  const current = new Date(start);
+  while (current <= end) {
+    days.push(current.toISOString().slice(0, 10));
+    current.setDate(current.getDate() + 1);
+  }
+  return days;
+}
+
+/**
+ * Calcula EMA (Exponential Moving Average) de TSS con una constante de tiempo dada.
+ * Itera día a día desde la primera actividad hasta targetDate.
+ */
+function calculateEMA(
+  activities: TrainingActivityInput[],
+  targetDate: string,
+  timeConstant: number,
+): number {
+  if (activities.length === 0) return 0;
+
+  const dailyTSS = buildDailyTSSMap(activities);
+
+  const sortedDates = [...dailyTSS.keys()].sort();
+  const firstDate = new Date(sortedDates[0]);
+  const endDate = new Date(targetDate);
+
+  if (endDate < firstDate) return 0;
+
+  const days = dayRange(firstDate, endDate);
+  let ema = 0;
+
+  for (const day of days) {
+    const tss = dailyTSS.get(day) ?? 0;
+    ema = ema + (tss - ema) / timeConstant;
+  }
+
+  return Math.round(ema * 10) / 10;
+}
+
+/**
+ * Chronic Training Load (Fitness): EMA de TSS con constante de 42 días.
+ * Representa la aptitud física acumulada.
+ */
+export function calculateCTL(activities: TrainingActivityInput[], targetDate: string): number {
+  return calculateEMA(activities, targetDate, 42);
+}
+
+/**
+ * Acute Training Load (Fatigue): EMA de TSS con constante de 7 días.
+ * Representa la fatiga reciente.
+ */
+export function calculateATL(activities: TrainingActivityInput[], targetDate: string): number {
+  return calculateEMA(activities, targetDate, 7);
+}
+
+/**
+ * Training Load completo: CTL, ATL y TSB en una sola llamada.
+ * TSB = CTL - ATL (positivo → buena forma, negativo → fatiga).
+ */
+export function calculateTrainingLoad(
+  activities: TrainingActivityInput[],
+  targetDate: string,
+): TrainingLoad {
+  const ctl = calculateCTL(activities, targetDate);
+  const atl = calculateATL(activities, targetDate);
+  const tsb = Math.round((ctl - atl) * 10) / 10;
+  return { ctl, atl, tsb };
+}
+
+/**
+ * Suma de TSS en una semana (lunes a domingo).
+ * @param weekStartDate - Fecha del lunes en formato YYYY-MM-DD
+ */
+export function calculateWeeklyTSS(
+  activities: TrainingActivityInput[],
+  weekStartDate: string,
+): number {
+  const start = new Date(weekStartDate);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 6);
+
+  const startStr = start.toISOString().slice(0, 10);
+  const endStr = end.toISOString().slice(0, 10);
+
+  return activities
+    .filter((a) => {
+      const day = a.date.slice(0, 10);
+      return day >= startStr && day <= endStr;
+    })
+    .reduce((sum, a) => sum + (a.tss ?? 0), 0);
+}
+
+/**
+ * Clasifica la zona dominante de una actividad según potencia media vs FTP.
+ * Usa POWER_ZONES de constants/zones.ts.
+ */
+export function classifyActivityZone(
+  avgPower: number | null,
+  ftp: number | null,
+): string | null {
+  if (!avgPower || !ftp) return null;
+  const ratio = avgPower / ftp;
+  const zone = POWER_ZONES.find((z) => ratio >= z.minPct && ratio <= z.maxPct);
+  return zone?.zone ?? null;
+}

--- a/packages/shared/src/utils/training-rules.test.ts
+++ b/packages/shared/src/utils/training-rules.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkOverloadAlert,
+  checkRestAlert,
+  checkDetrainingAlert,
+  checkRampRateAlert,
+  evaluateTrainingAlerts,
+} from "./training-rules";
+
+describe("training-rules", () => {
+  describe("checkOverloadAlert", () => {
+    it("none cuando TSS semanal < 120% del promedio", () => {
+      const result = checkOverloadAlert(100, 100);
+      expect(result.level).toBe("none");
+    });
+
+    it("warning cuando TSS semanal entre 120-149%", () => {
+      const result = checkOverloadAlert(130, 100);
+      expect(result.level).toBe("warning");
+      expect(result.type).toBe("overload");
+      expect(result.message).toContain("130%");
+    });
+
+    it("critical cuando TSS semanal ≥ 150%", () => {
+      const result = checkOverloadAlert(160, 100);
+      expect(result.level).toBe("critical");
+      expect(result.type).toBe("overload");
+    });
+
+    it("none cuando avgWeeklyTSS = 0", () => {
+      const result = checkOverloadAlert(200, 0);
+      expect(result.level).toBe("none");
+    });
+  });
+
+  describe("checkRestAlert", () => {
+    it("warning con 3 días consecutivos de TSS ≥ 80", () => {
+      const activities = [
+        { date: "2026-02-10", tss: 90, rpe: null },
+        { date: "2026-02-11", tss: 85, rpe: null },
+        { date: "2026-02-12", tss: 100, rpe: null },
+      ];
+      const result = checkRestAlert(activities);
+      expect(result.level).toBe("warning");
+      expect(result.type).toBe("rest_needed");
+    });
+
+    it("critical con 4+ días consecutivos de alta intensidad", () => {
+      const activities = [
+        { date: "2026-02-10", tss: 90, rpe: null },
+        { date: "2026-02-11", tss: 85, rpe: null },
+        { date: "2026-02-12", tss: 100, rpe: null },
+        { date: "2026-02-13", tss: 80, rpe: null },
+      ];
+      const result = checkRestAlert(activities);
+      expect(result.level).toBe("critical");
+    });
+
+    it("none con 2 días consecutivos (no alcanza umbral)", () => {
+      const activities = [
+        { date: "2026-02-10", tss: 90, rpe: null },
+        { date: "2026-02-11", tss: 85, rpe: null },
+      ];
+      const result = checkRestAlert(activities);
+      expect(result.level).toBe("none");
+    });
+
+    it("detecta intensidad alta por RPE ≥ 8", () => {
+      const activities = [
+        { date: "2026-02-10", tss: 50, rpe: 9 },
+        { date: "2026-02-11", tss: 40, rpe: 8 },
+        { date: "2026-02-12", tss: 30, rpe: 10 },
+      ];
+      const result = checkRestAlert(activities);
+      expect(result.level).toBe("warning");
+    });
+
+    it("none con lista vacía", () => {
+      const result = checkRestAlert([]);
+      expect(result.level).toBe("none");
+    });
+
+    it("no cuenta días no consecutivos", () => {
+      const activities = [
+        { date: "2026-02-10", tss: 90, rpe: null },
+        { date: "2026-02-11", tss: 85, rpe: null },
+        // gap de un día
+        { date: "2026-02-13", tss: 100, rpe: null },
+      ];
+      const result = checkRestAlert(activities);
+      expect(result.level).toBe("none");
+    });
+  });
+
+  describe("checkDetrainingAlert", () => {
+    it("warning sin actividad en 7+ días", () => {
+      const result = checkDetrainingAlert(0, "2026-02-01", "2026-02-08");
+      expect(result.level).toBe("warning");
+      expect(result.type).toBe("detraining");
+    });
+
+    it("critical sin actividad en 10+ días", () => {
+      const result = checkDetrainingAlert(0, "2026-02-01", "2026-02-11");
+      expect(result.level).toBe("critical");
+    });
+
+    it("none con actividad reciente", () => {
+      const result = checkDetrainingAlert(0, "2026-02-13", "2026-02-15");
+      expect(result.level).toBe("none");
+    });
+
+    it("warning cuando TSB > 25 (demasiado descanso)", () => {
+      const result = checkDetrainingAlert(30, "2026-02-14", "2026-02-15");
+      expect(result.level).toBe("warning");
+      expect(result.message).toContain("TSB");
+    });
+
+    it("none sin lastActivityDate y TSB normal", () => {
+      const result = checkDetrainingAlert(10, null, "2026-02-15");
+      expect(result.level).toBe("none");
+    });
+  });
+
+  describe("checkRampRateAlert", () => {
+    it("warning cuando CTL sube > 7 puntos/semana", () => {
+      const result = checkRampRateAlert(50, 42);
+      expect(result.level).toBe("warning");
+      expect(result.type).toBe("ramp_rate");
+    });
+
+    it("critical cuando CTL sube > 10 puntos/semana", () => {
+      const result = checkRampRateAlert(55, 42);
+      expect(result.level).toBe("critical");
+    });
+
+    it("none cuando CTL sube ≤ 7 puntos/semana", () => {
+      const result = checkRampRateAlert(47, 42);
+      expect(result.level).toBe("none");
+    });
+
+    it("none cuando CTL baja", () => {
+      const result = checkRampRateAlert(40, 50);
+      expect(result.level).toBe("none");
+    });
+  });
+
+  describe("evaluateTrainingAlerts", () => {
+    it("retorna solo alertas activas (level !== none)", () => {
+      const alerts = evaluateTrainingAlerts({
+        weeklyTSS: 150,
+        avgWeeklyTSS: 100,
+        recentActivities: [
+          { date: "2026-02-10", tss: 90, rpe: null },
+          { date: "2026-02-11", tss: 85, rpe: null },
+          { date: "2026-02-12", tss: 100, rpe: null },
+        ],
+        trainingLoad: { ctl: 50, atl: 80, tsb: -30 },
+        ctlPreviousWeek: 42,
+        lastActivityDate: "2026-02-12",
+        today: "2026-02-15",
+      });
+
+      // Overload: 150% → critical ✓
+      // Rest: 3 días → warning ✓
+      // Detraining: recent activity + TSB=-30 → none ✓
+      // Ramp rate: 50-42=8 > 7 → warning ✓
+      expect(alerts).toHaveLength(3);
+      expect(alerts.map((a) => a.type)).toContain("overload");
+      expect(alerts.map((a) => a.type)).toContain("rest_needed");
+      expect(alerts.map((a) => a.type)).toContain("ramp_rate");
+    });
+
+    it("retorna array vacío cuando todo está normal", () => {
+      const alerts = evaluateTrainingAlerts({
+        weeklyTSS: 100,
+        avgWeeklyTSS: 100,
+        recentActivities: [{ date: "2026-02-14", tss: 60, rpe: 6 }],
+        trainingLoad: { ctl: 45, atl: 50, tsb: -5 },
+        ctlPreviousWeek: 43,
+        lastActivityDate: "2026-02-14",
+        today: "2026-02-15",
+      });
+
+      expect(alerts).toHaveLength(0);
+    });
+  });
+});

--- a/packages/shared/src/utils/training-rules.ts
+++ b/packages/shared/src/utils/training-rules.ts
@@ -1,0 +1,201 @@
+import type { TrainingLoad } from "./training-calculations";
+
+export type AlertLevel = "none" | "warning" | "critical";
+
+export interface TrainingAlert {
+  type: "overload" | "rest_needed" | "detraining" | "ramp_rate";
+  level: AlertLevel;
+  message: string;
+}
+
+/**
+ * Alerta de sobrecarga semanal.
+ * ≥150% → critical, ≥120% → warning, <120% → none.
+ */
+export function checkOverloadAlert(weeklyTSS: number, avgWeeklyTSS: number): TrainingAlert {
+  if (avgWeeklyTSS === 0) {
+    return { type: "overload", level: "none", message: "" };
+  }
+
+  const percentage = (weeklyTSS / avgWeeklyTSS) * 100;
+
+  if (percentage >= 150) {
+    return {
+      type: "overload",
+      level: "critical",
+      message: `Tu carga semanal (TSS ${weeklyTSS}) es un ${Math.round(percentage)}% del promedio. Riesgo alto de sobreentrenamiento.`,
+    };
+  }
+
+  if (percentage >= 120) {
+    return {
+      type: "overload",
+      level: "warning",
+      message: `Tu carga semanal (TSS ${weeklyTSS}) es un ${Math.round(percentage)}% del promedio. Vigila la recuperación.`,
+    };
+  }
+
+  return { type: "overload", level: "none", message: "" };
+}
+
+/**
+ * Alerta de descanso urgente: 3+ días consecutivos de intensidad alta.
+ * Intensidad alta: TSS ≥ 80 o RPE ≥ 8.
+ */
+export function checkRestAlert(
+  recentActivities: Array<{ date: string; tss: number | null; rpe: number | null }>,
+): TrainingAlert {
+  if (recentActivities.length === 0) {
+    return { type: "rest_needed", level: "none", message: "" };
+  }
+
+  const sorted = [...recentActivities].sort((a, b) => a.date.localeCompare(b.date));
+
+  // Group by day and check if any activity that day is "intense"
+  const dayIntense = new Map<string, boolean>();
+  for (const a of sorted) {
+    const day = a.date.slice(0, 10);
+    const isIntense = (a.tss != null && a.tss >= 80) || (a.rpe != null && a.rpe >= 8);
+    if (isIntense) {
+      dayIntense.set(day, true);
+    } else if (!dayIntense.has(day)) {
+      dayIntense.set(day, false);
+    }
+  }
+
+  // Find max consecutive intense days
+  const days = [...dayIntense.keys()].sort();
+  let maxConsecutive = 0;
+  let current = 0;
+
+  for (let i = 0; i < days.length; i++) {
+    if (dayIntense.get(days[i])) {
+      current++;
+      // Check that days are actually consecutive
+      if (i > 0 && current > 1) {
+        const prev = new Date(days[i - 1]);
+        const curr = new Date(days[i]);
+        const diffMs = curr.getTime() - prev.getTime();
+        const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+        if (diffDays !== 1) {
+          current = 1;
+        }
+      }
+      maxConsecutive = Math.max(maxConsecutive, current);
+    } else {
+      current = 0;
+    }
+  }
+
+  if (maxConsecutive >= 4) {
+    return {
+      type: "rest_needed",
+      level: "critical",
+      message: `Llevas ${maxConsecutive} días consecutivos de alta intensidad. Un día de descanso es urgente.`,
+    };
+  }
+
+  if (maxConsecutive >= 3) {
+    return {
+      type: "rest_needed",
+      level: "warning",
+      message: "Llevas 3 días consecutivos de alta intensidad. Considera un día de recuperación.",
+    };
+  }
+
+  return { type: "rest_needed", level: "none", message: "" };
+}
+
+/**
+ * Alerta de pérdida de forma (detraining).
+ * 10+ días sin actividad → critical, 7+ días → warning, TSB > 25 → warning.
+ */
+export function checkDetrainingAlert(
+  tsb: number,
+  lastActivityDate: string | null,
+  today: string,
+): TrainingAlert {
+  if (lastActivityDate) {
+    const last = new Date(lastActivityDate);
+    const now = new Date(today);
+    const diffMs = now.getTime() - last.getTime();
+    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays >= 10) {
+      return {
+        type: "detraining",
+        level: "critical",
+        message: `Llevas ${diffDays} días sin entrenar. Tu forma física puede estar disminuyendo significativamente.`,
+      };
+    }
+
+    if (diffDays >= 7) {
+      return {
+        type: "detraining",
+        level: "warning",
+        message: `Llevas ${diffDays} días sin entrenar. Intenta retomar la actividad para mantener tu forma.`,
+      };
+    }
+  }
+
+  if (tsb > 25) {
+    return {
+      type: "detraining",
+      level: "warning",
+      message:
+        "Tu TSB es muy alto, lo que indica mucho descanso relativo. Considera añadir carga para mantener la forma.",
+    };
+  }
+
+  return { type: "detraining", level: "none", message: "" };
+}
+
+/**
+ * Alerta de progresión excesiva (ramp rate).
+ * CTL delta > 10/semana → critical, > 7/semana → warning.
+ */
+export function checkRampRateAlert(ctlCurrent: number, ctlPreviousWeek: number): TrainingAlert {
+  const delta = ctlCurrent - ctlPreviousWeek;
+
+  if (delta > 10) {
+    return {
+      type: "ramp_rate",
+      level: "critical",
+      message: `Tu CTL ha subido ${Math.round(delta)} puntos en una semana. Riesgo alto de lesión por progresión excesiva.`,
+    };
+  }
+
+  if (delta > 7) {
+    return {
+      type: "ramp_rate",
+      level: "warning",
+      message: `Tu CTL ha subido ${Math.round(delta)} puntos en una semana. Modera el incremento de carga.`,
+    };
+  }
+
+  return { type: "ramp_rate", level: "none", message: "" };
+}
+
+export interface AlertParams {
+  weeklyTSS: number;
+  avgWeeklyTSS: number;
+  recentActivities: Array<{ date: string; tss: number | null; rpe: number | null }>;
+  trainingLoad: TrainingLoad;
+  ctlPreviousWeek: number;
+  lastActivityDate: string | null;
+  today: string;
+}
+
+/**
+ * Ejecuta todas las reglas de alerta y retorna solo las activas (level !== "none").
+ */
+export function evaluateTrainingAlerts(params: AlertParams): TrainingAlert[] {
+  const alerts: TrainingAlert[] = [
+    checkOverloadAlert(params.weeklyTSS, params.avgWeeklyTSS),
+    checkRestAlert(params.recentActivities),
+    checkDetrainingAlert(params.trainingLoad.tsb, params.lastActivityDate, params.today),
+    checkRampRateAlert(params.trainingLoad.ctl, params.ctlPreviousWeek),
+  ];
+
+  return alerts.filter((a) => a.level !== "none");
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Implementa funciones puras de cálculo de entrenamiento en `packages/shared/src/utils/training-calculations.ts`: `calculateIF`, `calculateTSS`, `calculateCTL`, `calculateATL`, `calculateTrainingLoad`, `calculateWeeklyTSS`, `classifyActivityZone`
- Implementa reglas de alerta en `packages/shared/src/utils/training-rules.ts`: `checkOverloadAlert`, `checkRestAlert`, `checkDetrainingAlert`, `checkRampRateAlert`, `evaluateTrainingAlerts`
- Re-exporta todas las funciones y tipos desde `packages/shared/src/index.ts`
- Excluye archivos `.test.ts` del build de shared (`tsconfig.json`)
- Añade spec L2 del Bloque 4 en `docs/specs/L2-backend-04-training-rules.md`

## Detalles técnicos
- **45 tests nuevos** (24 cálculos + 21 reglas), total shared: 77 tests
- **Total monorepo**: 213 tests (77 shared + 65 api + 71 web)
- Funciones puras sin side effects, reutilizables en backend (Bloque 5: IA) y frontend
- CTL/ATL usan EMA (Exponential Moving Average) estándar de ciclismo (42/7 días)
- Alertas: sobrecarga (120%/150%), descanso urgente (3+/4+ días intensos), detraining (7/10 días), ramp rate (>7/>10 CTL/semana)

## Test plan
- [x] `pnpm --filter shared test` → 77 tests pasan
- [x] `pnpm test` → 213 tests pasan (monorepo completo)
- [x] `pnpm build` → 3/3 paquetes OK
- [x] `pnpm lint` → 3/3 paquetes OK
- [x] `pnpm typecheck` → sin errores