### PR TITLE
feat: implementar CRUD de planes semanales (Bloque 6)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import profileRoutes from "./routes/profile.js";
 import activityRoutes from "./routes/activities.js";
 import insightsRoutes from "./routes/insights.js";
 import aiRoutes from "./routes/ai.js";
+import planRoutes from "./routes/plans.js";
 
 /**
  * Factory function to build and configure the Fastify application.
@@ -35,6 +36,7 @@ export async function buildApp(opts: FastifyServerOptions = {}): Promise<Fastify
       await scope.register(activityRoutes);
       await scope.register(insightsRoutes);
       await scope.register(aiRoutes);
+      await scope.register(planRoutes);
     },
     { prefix: "/api/v1" },
   );

--- a/apps/api/src/routes/plans.ts
+++ b/apps/api/src/routes/plans.ts
@@ -1,0 +1,38 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { planDaySchema } from "shared";
+import { AppError } from "../plugins/error-handler.js";
+import { getPlan, updatePlan, deletePlan } from "../services/plan.service.js";
+
+const updatePlanBodySchema = z.object({
+  week_start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  days: z.array(planDaySchema).length(7),
+});
+
+export default async function planRoutes(fastify: FastifyInstance) {
+  fastify.get("/plan", async (request) => {
+    const { week_start } = request.query as { week_start?: string };
+    const plan = await getPlan(request.userId, week_start);
+    return { data: plan };
+  });
+
+  fastify.patch("/plan", async (request) => {
+    const parsed = updatePlanBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      throw new AppError("Datos inválidos", 400, "BAD_REQUEST");
+    }
+
+    const result = await updatePlan(request.userId, parsed.data.week_start, parsed.data.days);
+    return { data: result };
+  });
+
+  fastify.delete("/plan", async (request, reply) => {
+    const { week_start } = request.query as { week_start?: string };
+    if (!week_start) {
+      throw new AppError("Missing required query param: week_start", 400, "BAD_REQUEST");
+    }
+
+    await deletePlan(request.userId, week_start);
+    return reply.status(204).send();
+  });
+}

--- a/apps/api/src/services/plan.service.test.ts
+++ b/apps/api/src/services/plan.service.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PlanDay } from "shared";
+import { AppError } from "../plugins/error-handler.js";
+
+const mockFrom = vi.fn();
+
+vi.mock("./supabase.js", () => ({
+  supabaseAdmin: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+const { getPlan, updatePlan, deletePlan, getWeekStart } = await import("./plan.service.js");
+
+const mockPlanRow = {
+  id: "plan-123",
+  user_id: "user-123",
+  week_start: "2026-02-10",
+  plan_data: {
+    days: Array.from({ length: 7 }, (_, i) => ({
+      day: ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"][i],
+      date: `2026-02-${10 + i}`,
+      type: i === 3 ? "rest" : "endurance",
+      title: i === 3 ? "Descanso" : "Rodaje",
+      intensity: i === 3 ? "—" : "media",
+      duration: i === 3 ? "—" : "1h",
+      description: "Descripción",
+      nutrition: "Nutrición",
+      rest: "Descanso",
+      done: false,
+      actual_power: null,
+    })),
+  },
+  ai_rationale: "Plan adaptado a tu objetivo.",
+  created_at: "2026-02-10T08:00:00Z",
+  updated_at: "2026-02-10T08:00:00Z",
+};
+
+function mockChain(result: { data: unknown; error: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const methods = ["select", "eq", "update", "delete", "single"];
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain["single"] = vi.fn().mockResolvedValue(result);
+  chain["then"] = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  mockFrom.mockReturnValue(chain);
+  return chain;
+}
+
+describe("plan.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getWeekStart", () => {
+    it("retorna lunes para una fecha entre semana", () => {
+      // 2026-02-11 es miércoles
+      const result = getWeekStart(new Date("2026-02-11"));
+      expect(result).toBe("2026-02-09");
+    });
+
+    it("retorna lunes para un domingo", () => {
+      // 2026-02-15 es domingo
+      const result = getWeekStart(new Date("2026-02-15"));
+      expect(result).toBe("2026-02-09");
+    });
+  });
+
+  describe("getPlan", () => {
+    it("retorna plan existente con días mapeados", async () => {
+      mockChain({ data: mockPlanRow, error: null });
+
+      const result = await getPlan("user-123", "2026-02-10");
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("plan-123");
+      expect(result!.days).toHaveLength(7);
+      expect(result!.week_start).toBe("2026-02-10");
+      expect(result!.ai_rationale).toBe("Plan adaptado a tu objetivo.");
+    });
+
+    it("retorna null si no existe plan", async () => {
+      mockChain({ data: null, error: { message: "not found" } });
+
+      const result = await getPlan("user-123", "2026-02-10");
+      expect(result).toBeNull();
+    });
+
+    it("retorna null ante error de Supabase", async () => {
+      mockChain({ data: null, error: { message: "connection error" } });
+
+      const result = await getPlan("user-123", "2026-02-10");
+      expect(result).toBeNull();
+    });
+
+    it("usa lunes actual si no se pasa week_start", async () => {
+      mockChain({ data: mockPlanRow, error: null });
+
+      const result = await getPlan("user-123");
+      expect(result).not.toBeNull();
+      expect(mockFrom).toHaveBeenCalledWith("weekly_plans");
+    });
+  });
+
+  describe("updatePlan", () => {
+    it("actualiza plan existente", async () => {
+      const updatedRow = {
+        ...mockPlanRow,
+        plan_data: {
+          days: mockPlanRow.plan_data.days.map((d, i) =>
+            i === 0 ? { ...d, done: true, actual_power: 200 } : d,
+          ),
+        },
+        updated_at: "2026-02-12T10:00:00Z",
+      };
+      mockChain({ data: updatedRow, error: null });
+
+      const days = updatedRow.plan_data.days as PlanDay[];
+      const result = await updatePlan("user-123", "2026-02-10", days);
+
+      expect(result.days[0].done).toBe(true);
+      expect(result.days[0].actual_power).toBe(200);
+    });
+
+    it("lanza 404 si plan no existe", async () => {
+      mockChain({ data: null, error: { message: "not found" } });
+
+      const days = mockPlanRow.plan_data.days as PlanDay[];
+      await expect(updatePlan("user-123", "2026-02-10", days)).rejects.toThrow(AppError);
+      await expect(updatePlan("user-123", "2026-02-10", days)).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+
+    it("lanza 404 ante error de Supabase", async () => {
+      mockChain({ data: null, error: { message: "connection error" } });
+
+      const days = mockPlanRow.plan_data.days as PlanDay[];
+      await expect(updatePlan("user-123", "2026-02-10", days)).rejects.toThrow(AppError);
+    });
+  });
+
+  describe("deletePlan", () => {
+    it("elimina plan existente sin error", async () => {
+      const chain: Record<string, unknown> = {};
+      const methods = ["delete", "eq"];
+      for (const m of methods) {
+        chain[m] = vi.fn().mockReturnValue(chain);
+      }
+      chain["then"] = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+        Promise.resolve({ error: null, count: 1 }).then(resolve, reject);
+      mockFrom.mockReturnValue(chain);
+
+      await expect(deletePlan("user-123", "2026-02-10")).resolves.toBeUndefined();
+    });
+
+    it("lanza 404 si plan no existe (count=0)", async () => {
+      const chain: Record<string, unknown> = {};
+      const methods = ["delete", "eq"];
+      for (const m of methods) {
+        chain[m] = vi.fn().mockReturnValue(chain);
+      }
+      chain["then"] = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+        Promise.resolve({ error: null, count: 0 }).then(resolve, reject);
+      mockFrom.mockReturnValue(chain);
+
+      await expect(deletePlan("user-123", "2026-02-10")).rejects.toThrow(AppError);
+      await expect(deletePlan("user-123", "2026-02-10")).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/apps/api/src/services/plan.service.ts
+++ b/apps/api/src/services/plan.service.ts
@@ -1,0 +1,93 @@
+import type { PlanDay } from "shared";
+import { supabaseAdmin } from "./supabase.js";
+import { AppError } from "../plugins/error-handler.js";
+
+export interface WeeklyPlanRow {
+  id: string;
+  user_id: string;
+  week_start: string;
+  plan_data: { days: PlanDay[] };
+  ai_rationale: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WeeklyPlanResponse {
+  id: string;
+  user_id: string;
+  week_start: string;
+  days: PlanDay[];
+  ai_rationale: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapRowToResponse(row: WeeklyPlanRow): WeeklyPlanResponse {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    week_start: row.week_start,
+    days: row.plan_data.days,
+    ai_rationale: row.ai_rationale,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export function getWeekStart(date: Date): string {
+  const d = new Date(date);
+  const dayOfWeek = d.getDay();
+  const diff = d.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
+  d.setDate(diff);
+  return d.toISOString().slice(0, 10);
+}
+
+export async function getPlan(
+  userId: string,
+  weekStart?: string,
+): Promise<WeeklyPlanResponse | null> {
+  const effectiveWeekStart = weekStart ?? getWeekStart(new Date());
+
+  const { data, error } = await supabaseAdmin
+    .from("weekly_plans")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("week_start", effectiveWeekStart)
+    .single();
+
+  if (error || !data) return null;
+
+  return mapRowToResponse(data as WeeklyPlanRow);
+}
+
+export async function updatePlan(
+  userId: string,
+  weekStart: string,
+  days: PlanDay[],
+): Promise<WeeklyPlanResponse> {
+  const { data, error } = await supabaseAdmin
+    .from("weekly_plans")
+    .update({ plan_data: { days } })
+    .eq("user_id", userId)
+    .eq("week_start", weekStart)
+    .select("*")
+    .single();
+
+  if (error || !data) {
+    throw new AppError("Plan no encontrado", 404, "NOT_FOUND");
+  }
+
+  return mapRowToResponse(data as WeeklyPlanRow);
+}
+
+export async function deletePlan(userId: string, weekStart: string): Promise<void> {
+  const { error, count } = await supabaseAdmin
+    .from("weekly_plans")
+    .delete()
+    .eq("user_id", userId)
+    .eq("week_start", weekStart);
+
+  if (error || count === 0) {
+    throw new AppError("Plan no encontrado", 404, "NOT_FOUND");
+  }
+}

--- a/docs/specs/L2-backend-06-weekly-plan.md
+++ b/docs/specs/L2-backend-06-weekly-plan.md
@@ -1,0 +1,102 @@
+# L2 — Bloque 6: Weekly Plan CRUD
+
+## Contexto
+
+La tabla `weekly_plans` y la generación IA (`POST /api/v1/ai/weekly-plan`) ya existen (Bloques 0 y 5).
+Este bloque añade endpoints CRUD para leer, actualizar y eliminar planes, permitiendo al frontend:
+- Mostrar el plan de la semana actual o de cualquier semana pasada.
+- Marcar días como completados (`done: true`, `actual_power`).
+- Navegar entre semanas.
+
+## Endpoints
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| GET | `/api/v1/plan?week_start=YYYY-MM-DD` | Obtener plan de una semana. Si no hay `week_start`, usa lunes actual. |
+| PATCH | `/api/v1/plan` | Actualizar plan (body: `{ week_start, days }`) |
+| DELETE | `/api/v1/plan?week_start=YYYY-MM-DD` | Eliminar plan de una semana |
+
+## Archivos
+
+| # | Archivo | Acción |
+|---|---------|--------|
+| 1 | `apps/api/src/services/plan.service.ts` | **Crear** — getPlan, updatePlan, deletePlan |
+| 2 | `apps/api/src/services/plan.service.test.ts` | **Crear** — ~10 tests |
+| 3 | `apps/api/src/routes/plans.ts` | **Crear** — 3 endpoints |
+| 4 | `apps/api/src/app.ts` | **Modificar** — registrar planRoutes |
+| 5 | `apps/api/src/routes/routes.integration.test.ts` | **Modificar** — ~6 tests integración |
+
+## Servicio (`plan.service.ts`)
+
+### `getPlan(userId, weekStart)`
+- Query: `SELECT * FROM weekly_plans WHERE user_id = ? AND week_start = ?`
+- La columna `plan_data` es JSONB con `{ days: PlanDay[] }`
+- Retorna `WeeklyPlan | null` (mapeando `plan_data.days` + metadatos)
+
+### `updatePlan(userId, weekStart, days)`
+- Update: `UPDATE weekly_plans SET plan_data = { days }, updated_at = NOW() WHERE user_id = ? AND week_start = ?`
+- Valida input con Zod
+- Retorna plan actualizado
+- Si no existe → AppError 404
+
+### `deletePlan(userId, weekStart)`
+- Delete: `DELETE FROM weekly_plans WHERE user_id = ? AND week_start = ?`
+- Retorna void (204)
+
+## Respuestas
+
+### GET /api/v1/plan
+```json
+// 200 — plan encontrado
+{
+  "data": {
+    "id": "uuid",
+    "user_id": "uuid",
+    "week_start": "2026-02-10",
+    "days": [ /* 7 PlanDay */ ],
+    "ai_rationale": "Plan adaptado...",
+    "created_at": "2026-02-10T08:00:00Z",
+    "updated_at": "2026-02-10T08:00:00Z"
+  }
+}
+
+// 200 — sin plan
+{ "data": null }
+```
+
+### PATCH /api/v1/plan
+```json
+// Body
+{
+  "week_start": "2026-02-10",
+  "days": [ /* 7 PlanDay actualizados */ ]
+}
+
+// 200 — actualizado
+{ "data": { /* plan completo */ } }
+```
+
+### DELETE /api/v1/plan
+```
+204 No Content
+```
+
+## Tests esperados
+
+### Unit tests (`plan.service.test.ts`)
+1. getPlan retorna plan existente con días mapeados
+2. getPlan retorna null si no existe
+3. getPlan maneja error de Supabase
+4. updatePlan actualiza plan existente
+5. updatePlan lanza 404 si no existe
+6. updatePlan maneja error de Supabase
+7. deletePlan elimina plan existente
+8. deletePlan lanza 404 si no existe
+
+### Integration tests (`routes.integration.test.ts`)
+1. GET /api/v1/plan con week_start devuelve 200 con plan
+2. GET /api/v1/plan sin week_start usa lunes actual
+3. GET /api/v1/plan sin plan devuelve 200 con null
+4. PATCH /api/v1/plan devuelve 200 con plan actualizado
+5. DELETE /api/v1/plan devuelve 204
+6. Rutas plan sin auth devuelven 401


### PR DESCRIPTION
## Summary
- Añade 3 endpoints CRUD para planes semanales en `/api/v1/plan`
- **GET /plan?week_start=**: Obtener plan de una semana (devuelve null si no existe)
- **PATCH /plan**: Actualizar plan (marcar días como completados, registrar potencia real)
- **DELETE /plan?week_start=**: Eliminar plan de una semana
- Complementa la generación IA del Bloque 5 (`POST /api/v1/ai/weekly-plan`)

## Archivos
| Archivo | Descripción |
|---------|-------------|
| `apps/api/src/services/plan.service.ts` | getPlan, updatePlan, deletePlan |
| `apps/api/src/services/plan.service.test.ts` | 11 unit tests |
| `apps/api/src/routes/plans.ts` | 3 endpoints con validación Zod |
| `apps/api/src/routes/routes.integration.test.ts` | +7 tests de integración |
| `docs/specs/L2-backend-06-weekly-plan.md` | Spec técnica |

## Tests
- **114 tests API** (8 archivos) — 18 tests nuevos
- **262 tests totales** (114 api + 77 shared + 71 web)

## Test plan
- [x] CI backend pasa (lint + typecheck + tests)
- [x] CI frontend pasa (build + tests)
- [x] Endpoints existentes no afectados