### PR TITLE
feat: importación de archivos .fit/.gpx (Bloque 7)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,9 +17,12 @@
     "@fastify/cors": "^11.2.0",
     "@fastify/multipart": "^9.4.0",
     "@supabase/supabase-js": "^2.95.3",
+    "@we-gold/gpxjs": "^1.1.0",
+    "@xmldom/xmldom": "^0.8.11",
     "dotenv": "^16.4.7",
     "fastify": "^5.2.0",
     "fastify-plugin": "^5.1.0",
+    "fit-file-parser": "^2.3.3",
     "shared": "workspace:*",
     "zod": "^3.24.1"
   },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import Fastify, { FastifyInstance, FastifyServerOptions } from "fastify";
+import multipart from "@fastify/multipart";
 import corsPlugin from "./plugins/cors.js";
 import { errorHandler } from "./plugins/error-handler.js";
 import authPlugin from "./plugins/auth.js";
@@ -22,13 +23,16 @@ export async function buildApp(opts: FastifyServerOptions = {}): Promise<Fastify
   // 1. Register CORS plugin
   await fastify.register(corsPlugin);
 
-  // 2. Register error handler plugin
+  // 2. Register multipart plugin (file uploads, max 10MB)
+  await fastify.register(multipart, { limits: { fileSize: 10 * 1024 * 1024 } });
+
+  // 3. Register error handler plugin
   await fastify.register(errorHandler);
 
-  // 3. Register health routes (no prefix, public route)
+  // 4. Register health routes (no prefix, public route)
   await fastify.register(healthRoutes);
 
-  // 4. Register protected routes with /api/v1 prefix
+  // 5. Register protected routes with /api/v1 prefix
   await fastify.register(
     async function protectedRoutes(scope) {
       await scope.register(authPlugin);

--- a/apps/api/src/services/import.service.test.ts
+++ b/apps/api/src/services/import.service.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppError } from "../plugins/error-handler.js";
+
+// Mock supabase
+const mockFrom = vi.fn();
+vi.mock("./supabase.js", () => ({
+  supabaseAdmin: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+// Mock FitParser
+const mockParseAsync = vi.fn();
+vi.mock("fit-file-parser", () => {
+  class MockFitParser {
+    parseAsync = mockParseAsync;
+  }
+  return { default: MockFitParser };
+});
+
+// Mock gpxjs
+const mockParseGPXWithCustomParser = vi.fn();
+vi.mock("@we-gold/gpxjs", () => ({
+  parseGPXWithCustomParser: (...args: unknown[]) => mockParseGPXWithCustomParser(...args),
+}));
+
+// Mock xmldom
+vi.mock("@xmldom/xmldom", () => ({
+  DOMParser: vi.fn().mockImplementation(() => ({
+    parseFromString: vi.fn(),
+  })),
+}));
+
+const { parseFitBuffer, parseGpxString, processUpload } = await import("./import.service.js");
+
+const mockFitData = {
+  sessions: [
+    {
+      start_time: "2026-02-15T08:00:00Z",
+      total_timer_time: 3600,
+      total_distance: 45.2,
+      avg_power: 205,
+      avg_heart_rate: 148,
+      max_heart_rate: 178,
+      avg_cadence: 88,
+    },
+  ],
+  records: [
+    {
+      timestamp: "2026-02-15T08:00:00Z",
+      power: 200,
+      heart_rate: 140,
+      cadence: 85,
+      speed: 30,
+    },
+    {
+      timestamp: "2026-02-15T08:00:01Z",
+      power: 210,
+      heart_rate: 145,
+      cadence: 90,
+      speed: 31,
+    },
+    {
+      timestamp: "2026-02-15T08:00:02Z",
+      power: 195,
+      heart_rate: 150,
+      cadence: 87,
+      speed: 29,
+    },
+  ],
+};
+
+const mockGpxParsed = {
+  tracks: [
+    {
+      name: "Ruta Sierra Norte",
+      points: [
+        {
+          latitude: 40.4,
+          longitude: -3.7,
+          elevation: 650,
+          time: new Date("2026-02-15T09:00:00Z"),
+          extensions: { power: 200, heartRate: 140, cadence: 85, speed: 8.3 },
+        },
+        {
+          latitude: 40.41,
+          longitude: -3.71,
+          elevation: 660,
+          time: new Date("2026-02-15T09:00:01Z"),
+          extensions: { power: 210, heartRate: 148, cadence: 90, speed: 8.6 },
+        },
+      ],
+      distance: { total: 45200, cumulative: [0, 45200] },
+      duration: {
+        totalDuration: 3600,
+        movingDuration: 3500,
+        startTime: new Date("2026-02-15T09:00:00Z"),
+        endTime: new Date("2026-02-15T10:00:00Z"),
+        cumulative: [0, 1],
+      },
+      elevation: { maximum: 700, minimum: 600, positive: 500, negative: 400, average: 650 },
+      slopes: [0.5],
+    },
+  ],
+  waypoints: [],
+  routes: [],
+  metadata: { name: null, description: null, link: null, author: null, time: null },
+};
+
+function mockSupabaseChain(result: { data: unknown; error: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const methods = ["select", "eq", "insert", "update", "single", "order", "range", "gte", "lte"];
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain["single"] = vi.fn().mockResolvedValue(result);
+  chain["then"] = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+describe("import.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("parseFitBuffer", () => {
+    it("extrae datos de sesión y métricas de un .fit válido", async () => {
+      mockParseAsync.mockResolvedValue(mockFitData);
+
+      const result = await parseFitBuffer(Buffer.from("fake-fit-data"));
+
+      expect(result.date).toBe("2026-02-15");
+      expect(result.durationSeconds).toBe(3600);
+      expect(result.distanceKm).toBe(45.2);
+      expect(result.avgPowerWatts).toBe(205);
+      expect(result.avgHrBpm).toBe(148);
+      expect(result.maxHrBpm).toBe(178);
+      expect(result.avgCadenceRpm).toBe(88);
+      expect(result.metrics).toHaveLength(3);
+      expect(result.metrics[0]).toMatchObject({
+        timestampSeconds: 0,
+        powerWatts: 200,
+        hrBpm: 140,
+        cadenceRpm: 85,
+      });
+      expect(result.metrics[1].timestampSeconds).toBe(1);
+      expect(result.metrics[2].timestampSeconds).toBe(2);
+    });
+
+    it("lanza error si el parser falla", async () => {
+      mockParseAsync.mockRejectedValue(new Error("Invalid FIT"));
+
+      await expect(parseFitBuffer(Buffer.from("bad-data"))).rejects.toThrow(AppError);
+      await expect(parseFitBuffer(Buffer.from("bad-data"))).rejects.toMatchObject({
+        statusCode: 400,
+      });
+    });
+
+    it("lanza error si no hay sesión", async () => {
+      mockParseAsync.mockResolvedValue({ sessions: [], records: [] });
+
+      await expect(parseFitBuffer(Buffer.from("no-session"))).rejects.toThrow(AppError);
+    });
+
+    it("maneja campos opcionales ausentes", async () => {
+      mockParseAsync.mockResolvedValue({
+        sessions: [
+          {
+            start_time: "2026-02-15T08:00:00Z",
+            total_timer_time: 1800,
+          },
+        ],
+        records: [],
+      });
+
+      const result = await parseFitBuffer(Buffer.from("minimal-fit"));
+
+      expect(result.durationSeconds).toBe(1800);
+      expect(result.distanceKm).toBeNull();
+      expect(result.avgPowerWatts).toBeNull();
+      expect(result.avgHrBpm).toBeNull();
+      expect(result.metrics).toHaveLength(0);
+    });
+  });
+
+  describe("parseGpxString", () => {
+    it("extrae datos de track y métricas de un .gpx válido", () => {
+      mockParseGPXWithCustomParser.mockReturnValue([mockGpxParsed, null]);
+
+      const result = parseGpxString("<gpx>fake</gpx>");
+
+      expect(result.name).toBe("Ruta Sierra Norte");
+      expect(result.date).toBe("2026-02-15");
+      expect(result.durationSeconds).toBe(3600);
+      expect(result.distanceKm).toBe(45.2);
+      expect(result.avgPowerWatts).toBe(205);
+      expect(result.avgHrBpm).toBe(144);
+      expect(result.maxHrBpm).toBe(148);
+      expect(result.avgCadenceRpm).toBe(88);
+      expect(result.metrics).toHaveLength(2);
+      expect(result.metrics[0].timestampSeconds).toBe(0);
+      expect(result.metrics[1].timestampSeconds).toBe(1);
+    });
+
+    it("lanza error si el parser falla", () => {
+      mockParseGPXWithCustomParser.mockReturnValue([null, new Error("Invalid GPX")]);
+
+      expect(() => parseGpxString("<bad-gpx>")).toThrow(AppError);
+    });
+
+    it("lanza error si no hay tracks", () => {
+      mockParseGPXWithCustomParser.mockReturnValue([
+        { ...mockGpxParsed, tracks: [] },
+        null,
+      ]);
+
+      expect(() => parseGpxString("<empty-gpx>")).toThrow(AppError);
+    });
+
+    it("maneja puntos sin extensions", () => {
+      const noExtParsed = {
+        ...mockGpxParsed,
+        tracks: [
+          {
+            ...mockGpxParsed.tracks[0],
+            name: null,
+            points: [
+              {
+                latitude: 40.4,
+                longitude: -3.7,
+                elevation: 650,
+                time: new Date("2026-02-15T09:00:00Z"),
+                extensions: null,
+              },
+            ],
+          },
+        ],
+      };
+      mockParseGPXWithCustomParser.mockReturnValue([noExtParsed, null]);
+
+      const result = parseGpxString("<gpx>no-ext</gpx>");
+
+      expect(result.avgPowerWatts).toBeNull();
+      expect(result.avgHrBpm).toBeNull();
+      expect(result.avgCadenceRpm).toBeNull();
+      expect(result.metrics[0].powerWatts).toBeNull();
+    });
+  });
+
+  describe("processUpload", () => {
+    const mockActivity = {
+      id: "act-new",
+      user_id: "user-123",
+      name: "Actividad 2026-02-15",
+      date: "2026-02-15",
+      type: "endurance",
+      duration_seconds: 3600,
+      distance_km: 45.2,
+      avg_power_watts: 205,
+      avg_hr_bpm: 148,
+      max_hr_bpm: 178,
+      avg_cadence_rpm: 88,
+      tss: 55,
+      rpe: null,
+      ai_analysis: null,
+      notes: null,
+      is_reference: false,
+      raw_file_url: null,
+      created_at: "2026-02-15T08:00:00Z",
+      updated_at: "2026-02-15T08:00:00Z",
+    };
+
+    const mockProfile = {
+      id: "user-123",
+      email: "test@test.com",
+      display_name: "Test",
+      age: 42,
+      weight_kg: 75,
+      ftp: 250,
+      max_hr: 185,
+      rest_hr: 55,
+      goal: "performance",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    function setupMocks() {
+      mockParseAsync.mockResolvedValue(mockFitData);
+
+      mockFrom.mockImplementation((table: string) => {
+        const chain = mockSupabaseChain({ data: null, error: null });
+
+        if (table === "users") {
+          chain["single"] = vi.fn().mockResolvedValue({ data: mockProfile, error: null });
+        }
+        if (table === "activities") {
+          chain["single"] = vi.fn().mockResolvedValue({ data: mockActivity, error: null });
+        }
+        return chain;
+      });
+    }
+
+    it("procesa un .fit: crea actividad e inserta métricas", async () => {
+      setupMocks();
+
+      const result = await processUpload("user-123", Buffer.from("fit-data"), "ride.fit");
+
+      expect(result.activityId).toBe("act-new");
+      expect(result.metricsCount).toBe(3);
+      expect(mockFrom).toHaveBeenCalledWith("activity_metrics");
+    });
+
+    it("procesa un .gpx: crea actividad e inserta métricas", async () => {
+      mockParseGPXWithCustomParser.mockReturnValue([mockGpxParsed, null]);
+
+      mockFrom.mockImplementation((table: string) => {
+        const chain = mockSupabaseChain({ data: null, error: null });
+        if (table === "users") {
+          chain["single"] = vi.fn().mockResolvedValue({ data: mockProfile, error: null });
+        }
+        if (table === "activities") {
+          chain["single"] = vi.fn().mockResolvedValue({ data: mockActivity, error: null });
+        }
+        return chain;
+      });
+
+      const result = await processUpload(
+        "user-123",
+        Buffer.from("<gpx>data</gpx>"),
+        "ride.gpx",
+      );
+
+      expect(result.activityId).toBe("act-new");
+      expect(result.metricsCount).toBe(2);
+    });
+
+    it("aplica overrides de nombre y tipo", async () => {
+      setupMocks();
+
+      const result = await processUpload("user-123", Buffer.from("fit-data"), "ride.fit", {
+        name: "Mi ruta custom",
+        type: "intervals",
+        rpe: 7,
+        notes: "Buena sesión",
+      });
+
+      expect(result.activityId).toBe("act-new");
+    });
+
+    it("lanza error con formato no soportado", async () => {
+      await expect(
+        processUpload("user-123", Buffer.from("data"), "ride.csv"),
+      ).rejects.toThrow(AppError);
+
+      await expect(
+        processUpload("user-123", Buffer.from("data"), "ride.csv"),
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("lanza error si la duración es 0", async () => {
+      mockParseAsync.mockResolvedValue({
+        sessions: [{ start_time: "2026-02-15T08:00:00Z", total_timer_time: 0 }],
+        records: [],
+      });
+
+      await expect(
+        processUpload("user-123", Buffer.from("data"), "empty.fit"),
+      ).rejects.toThrow(AppError);
+    });
+  });
+});

--- a/apps/api/src/services/import.service.ts
+++ b/apps/api/src/services/import.service.ts
@@ -1,0 +1,263 @@
+import FitParser from "fit-file-parser";
+import { parseGPXWithCustomParser } from "@we-gold/gpxjs";
+import { DOMParser } from "@xmldom/xmldom";
+import type { ActivityType } from "shared";
+import { supabaseAdmin } from "./supabase.js";
+import { createActivity } from "./activity.service.js";
+import { getProfile } from "./profile.service.js";
+import { AppError } from "../plugins/error-handler.js";
+
+/** Datos extraídos del parseo de un archivo .fit o .gpx */
+export interface ParsedActivityData {
+  name: string;
+  date: string;
+  durationSeconds: number;
+  distanceKm: number | null;
+  avgPowerWatts: number | null;
+  avgHrBpm: number | null;
+  maxHrBpm: number | null;
+  avgCadenceRpm: number | null;
+  metrics: ParsedMetric[];
+}
+
+export interface ParsedMetric {
+  timestampSeconds: number;
+  powerWatts: number | null;
+  hrBpm: number | null;
+  cadenceRpm: number | null;
+  speedKmh: number | null;
+}
+
+/**
+ * Parsea un buffer de archivo .fit y extrae datos de actividad + métricas.
+ */
+export async function parseFitBuffer(buffer: Buffer): Promise<ParsedActivityData> {
+  const parser = new FitParser({ force: true, speedUnit: "km/h", lengthUnit: "km" });
+
+  let fit;
+  try {
+    fit = await parser.parseAsync(buffer as Buffer<ArrayBuffer>);
+  } catch {
+    throw new AppError("Error al parsear archivo .fit", 400, "INVALID_FILE");
+  }
+
+  const session = fit.sessions?.[0];
+  const records = fit.records ?? [];
+
+  if (!session) {
+    throw new AppError("Archivo .fit sin datos de sesión", 400, "INVALID_FILE");
+  }
+
+  const startTime = new Date(session.start_time);
+  const date = startTime.toISOString().slice(0, 10);
+  const durationSeconds = Math.round(session.total_timer_time ?? session.total_elapsed_time ?? 0);
+
+  // Distancia: total_distance viene en km si lengthUnit='km'
+  const distanceKm = session.total_distance
+    ? Math.round(session.total_distance * 100) / 100
+    : null;
+
+  const avgPowerWatts = session.avg_power ? Math.round(session.avg_power) : null;
+  const avgHrBpm = session.avg_heart_rate ? Math.round(session.avg_heart_rate) : null;
+  const maxHrBpm = session.max_heart_rate ? Math.round(session.max_heart_rate) : null;
+  const avgCadenceRpm = session.avg_cadence ? Math.round(session.avg_cadence) : null;
+
+  // Extraer métricas segundo a segundo de los records
+  const metrics: ParsedMetric[] = [];
+  const baseTimestamp = records[0]?.timestamp ? new Date(records[0].timestamp).getTime() : 0;
+
+  for (const record of records) {
+    if (!record.timestamp) continue;
+    const recordTime = new Date(record.timestamp).getTime();
+    const timestampSeconds = Math.round((recordTime - baseTimestamp) / 1000);
+
+    metrics.push({
+      timestampSeconds,
+      powerWatts: record.power ?? null,
+      hrBpm: record.heart_rate ?? null,
+      cadenceRpm: record.cadence ?? null,
+      speedKmh: record.speed ? Math.round(record.speed * 100) / 100 : null,
+    });
+  }
+
+  return {
+    name: `Actividad ${date}`,
+    date,
+    durationSeconds,
+    distanceKm,
+    avgPowerWatts,
+    avgHrBpm,
+    maxHrBpm,
+    avgCadenceRpm,
+    metrics,
+  };
+}
+
+/**
+ * Parsea un string XML de archivo .gpx y extrae datos de actividad + métricas.
+ */
+export function parseGpxString(xmlString: string): ParsedActivityData {
+  const customParser = (txt: string) => new DOMParser().parseFromString(txt, "text/xml");
+
+  const [parsed, error] = parseGPXWithCustomParser(xmlString, customParser, {
+    removeEmptyFields: true,
+    avgSpeedThreshold: 0.1,
+  });
+
+  if (error || !parsed) {
+    throw new AppError("Error al parsear archivo .gpx", 400, "INVALID_FILE");
+  }
+
+  const track = parsed.tracks[0];
+  if (!track || track.points.length === 0) {
+    throw new AppError("Archivo .gpx sin datos de track", 400, "INVALID_FILE");
+  }
+
+  const startTime = track.points[0].time ?? new Date();
+  const date = new Date(startTime).toISOString().slice(0, 10);
+  const durationSeconds = Math.round(track.duration.totalDuration);
+  const distanceKm = track.distance.total
+    ? Math.round((track.distance.total / 1000) * 100) / 100
+    : null;
+
+  // Calcular medias desde los puntos
+  let totalPower = 0;
+  let powerCount = 0;
+  let totalHr = 0;
+  let hrCount = 0;
+  let maxHr = 0;
+  let totalCadence = 0;
+  let cadenceCount = 0;
+
+  const baseTime = track.points[0].time ? new Date(track.points[0].time).getTime() : 0;
+
+  const metrics: ParsedMetric[] = [];
+
+  for (const point of track.points) {
+    const ext = point.extensions;
+    const power = ext?.power != null ? Number(ext.power) : null;
+    const hr = ext?.heartRate != null ? Number(ext.heartRate) : null;
+    const cadence = ext?.cadence != null ? Number(ext.cadence) : null;
+    const speed = ext?.speed != null ? Number(ext.speed) : null;
+
+    if (power != null && !isNaN(power)) {
+      totalPower += power;
+      powerCount++;
+    }
+    if (hr != null && !isNaN(hr)) {
+      totalHr += hr;
+      hrCount++;
+      if (hr > maxHr) maxHr = hr;
+    }
+    if (cadence != null && !isNaN(cadence)) {
+      totalCadence += cadence;
+      cadenceCount++;
+    }
+
+    const pointTime = point.time ? new Date(point.time).getTime() : 0;
+    const timestampSeconds = baseTime ? Math.round((pointTime - baseTime) / 1000) : 0;
+
+    metrics.push({
+      timestampSeconds,
+      powerWatts: power,
+      hrBpm: hr,
+      cadenceRpm: cadence,
+      speedKmh: speed ? Math.round(speed * 3.6 * 100) / 100 : null,
+    });
+  }
+
+  return {
+    name: track.name ?? `Actividad ${date}`,
+    date,
+    durationSeconds,
+    distanceKm,
+    avgPowerWatts: powerCount > 0 ? Math.round(totalPower / powerCount) : null,
+    avgHrBpm: hrCount > 0 ? Math.round(totalHr / hrCount) : null,
+    maxHrBpm: maxHr > 0 ? Math.round(maxHr) : null,
+    avgCadenceRpm: cadenceCount > 0 ? Math.round(totalCadence / cadenceCount) : null,
+    metrics,
+  };
+}
+
+/**
+ * Procesa el upload completo: parsea archivo, crea actividad, inserta métricas.
+ */
+export async function processUpload(
+  userId: string,
+  fileBuffer: Buffer,
+  fileName: string,
+  overrides?: {
+    name?: string;
+    type?: ActivityType;
+    rpe?: number;
+    notes?: string;
+  },
+): Promise<{ activityId: string; metricsCount: number }> {
+  const ext = fileName.toLowerCase().split(".").pop();
+
+  let parsed: ParsedActivityData;
+  if (ext === "fit") {
+    parsed = await parseFitBuffer(fileBuffer);
+  } else if (ext === "gpx") {
+    parsed = parseGpxString(fileBuffer.toString("utf-8"));
+  } else {
+    throw new AppError("Formato no soportado. Usa .fit o .gpx", 400, "UNSUPPORTED_FORMAT");
+  }
+
+  if (parsed.durationSeconds <= 0) {
+    throw new AppError("El archivo no contiene datos de duración válidos", 400, "INVALID_FILE");
+  }
+
+  // Obtener FTP del usuario para calcular TSS
+  const profile = await getProfile(userId);
+
+  const activity = await createActivity(
+    userId,
+    {
+      name: overrides?.name || parsed.name,
+      date: parsed.date,
+      type: overrides?.type ?? "endurance",
+      duration_seconds: parsed.durationSeconds,
+      distance_km: parsed.distanceKm,
+      avg_power_watts: parsed.avgPowerWatts,
+      avg_hr_bpm: parsed.avgHrBpm,
+      max_hr_bpm: parsed.maxHrBpm,
+      avg_cadence_rpm: parsed.avgCadenceRpm,
+      rpe: overrides?.rpe ?? null,
+      notes: overrides?.notes ?? null,
+    },
+    profile.ftp,
+  );
+
+  // Insertar métricas en batch (si hay)
+  let metricsCount = 0;
+  if (parsed.metrics.length > 0) {
+    const metricsRows = parsed.metrics.map((m) => ({
+      activity_id: activity.id,
+      timestamp_seconds: m.timestampSeconds,
+      power_watts: m.powerWatts,
+      hr_bpm: m.hrBpm,
+      cadence_rpm: m.cadenceRpm,
+      speed_kmh: m.speedKmh,
+    }));
+
+    // Insertar en bloques de 1000 para evitar límites
+    const BATCH_SIZE = 1000;
+    for (let i = 0; i < metricsRows.length; i += BATCH_SIZE) {
+      const batch = metricsRows.slice(i, i + BATCH_SIZE);
+      const { error } = await supabaseAdmin.from("activity_metrics").insert(batch);
+
+      if (error) {
+        throw new AppError(
+          `Error al guardar métricas: ${error.message}`,
+          500,
+          "DATABASE_ERROR",
+        );
+      }
+    }
+
+    metricsCount = metricsRows.length;
+  }
+
+  return { activityId: activity.id, metricsCount };
+}

--- a/docs/specs/L2-backend-07-import.md
+++ b/docs/specs/L2-backend-07-import.md
@@ -1,0 +1,84 @@
+# L2 — Bloque 7: Import / Upload de archivos .fit/.gpx
+
+## Contexto
+
+El frontend ya tiene una pantalla de importación (`/activities/import`) con dos modos:
+- **Manual**: Funcional — inserta directamente en Supabase desde el cliente
+- **Archivo**: Placeholder — muestra UI pero no procesa archivos
+
+Este bloque implementa el backend para el modo archivo: recibir un archivo `.fit` o `.gpx`,
+parsearlo, extraer métricas, crear la actividad y guardar las series temporales.
+
+## Endpoint
+
+```
+POST /api/v1/activities/upload
+Content-Type: multipart/form-data
+
+Fields:
+  file: archivo .fit o .gpx (max 10MB)
+  name?: string (opcional, se genera desde el archivo si no se proporciona)
+  type?: activity_type (opcional, default "endurance")
+  rpe?: number 1-10 (opcional)
+  notes?: string (opcional)
+```
+
+### Response 201
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "Morning Ride",
+    "date": "2026-02-15",
+    "type": "endurance",
+    "duration_seconds": 3600,
+    "distance_km": 45.2,
+    "avg_power_watts": 205,
+    "avg_hr_bpm": 148,
+    "max_hr_bpm": 178,
+    "avg_cadence_rpm": 88,
+    "tss": 68,
+    "metrics_count": 3600
+  }
+}
+```
+
+## Decisiones Arquitectónicas
+
+| Decisión | Elección | Rationale |
+|----------|----------|-----------|
+| Multipart | `@fastify/multipart` | Plugin oficial Fastify |
+| Parser .fit | `fit-file-parser` v2.x | Nativo TS, API async |
+| Parser .gpx | `@we-gold/gpxjs` + `@xmldom/xmldom` | Nativo TS, GPX completo |
+| Tamaño máx | 10 MB | Suficiente para archivos de actividad |
+| Métricas | Batch insert | Una sola query para todas las series temporales |
+| Storage | No en esta fase | `raw_file_url` queda null — se puede añadir después |
+
+## Flujo
+
+1. Recibir multipart file
+2. Validar extensión (.fit o .gpx) y tamaño
+3. Parsear archivo con el parser correspondiente
+4. Extraer datos de sesión: fecha, duración, distancia, métricas medias/máximas
+5. Extraer series temporales: power, hr, cadence, speed por segundo
+6. Crear actividad via `createActivity()` (reutiliza cálculo de TSS)
+7. Insertar métricas en `activity_metrics` (batch)
+8. Retornar actividad + count de métricas
+
+## Archivos
+
+| Archivo | Acción |
+|---------|--------|
+| `apps/api/src/services/import.service.ts` | Crear — parseo + procesado |
+| `apps/api/src/routes/activities.ts` | Modificar — añadir POST upload |
+| `apps/api/src/app.ts` | Modificar — registrar @fastify/multipart |
+| `apps/api/src/services/import.service.test.ts` | Crear — tests unitarios |
+| `apps/api/src/routes/routes.integration.test.ts` | Modificar — tests upload |
+
+## Tests
+
+- parseFitBuffer: extrae sesión y records correctamente
+- parseGpxString: extrae track points y métricas
+- processUpload: crea actividad + inserta métricas
+- Errores: archivo vacío, formato inválido, archivo demasiado grande
+- Integración: POST upload → 201, sin archivo → 400, sin auth → 401

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.95.3
         version: 2.95.3
+      '@we-gold/gpxjs':
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@xmldom/xmldom':
+        specifier: ^0.8.11
+        version: 0.8.11
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -62,6 +68,9 @@ importers:
       fastify-plugin:
         specifier: ^5.1.0
         version: 5.1.0
+      fit-file-parser:
+        specifier: ^2.3.3
+        version: 2.3.3
       shared:
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1359,6 +1368,13 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@we-gold/gpxjs@1.1.0':
+    resolution: {integrity: sha512-oH1QDdpyBR47XmhOJti6mXtN8bpLviI5hwY3I5koOb41WWZQtmIXSwSceXFv7HSLymBdnEz3bykJZffBTAoQeg==}
+
+  '@xmldom/xmldom@0.8.11':
+    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+    engines: {node: '>=10.0.0'}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1479,6 +1495,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -1504,6 +1523,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1903,6 +1925,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  fit-file-parser@2.3.3:
+    resolution: {integrity: sha512-TZPFfjkEev5TTd9RnZ4xn4k5ZSx2VZiKNjoZsHIkmQDK0S0XA7ebfdMLj76BK7kStsHh5WbK8Fmn/w85jgd0dA==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -2027,6 +2052,9 @@ packages:
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4214,6 +4242,10 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@we-gold/gpxjs@1.1.0': {}
+
+  '@xmldom/xmldom@0.8.11': {}
+
   abstract-logging@2.0.1: {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -4350,6 +4382,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   bidi-js@1.0.3:
@@ -4378,6 +4412,11 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4918,6 +4957,10 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  fit-file-parser@2.3.3:
+    dependencies:
+      buffer: 6.0.3
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.3
@@ -5047,6 +5090,8 @@ snapshots:
       - supports-color
 
   iceberg-js@0.8.1: {}
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary
- Añade endpoint `POST /api/v1/activities/upload` para importar archivos de actividad
- Soporta **.fit** (Garmin, Wahoo, etc.) y **.gpx** (GPS Exchange Format)
- Extrae automáticamente: fecha, duración, distancia, potencia, FC, cadencia
- Inserta series temporales en `activity_metrics` (batch de 1000)
- Calcula TSS usando FTP del perfil del usuario
- Acepta campos opcionales: `name`, `type`, `rpe`, `notes`

## Archivos
| Archivo | Descripción |
|---------|-------------|
| `apps/api/src/services/import.service.ts` | parseFitBuffer, parseGpxString, processUpload |
| `apps/api/src/services/import.service.test.ts` | 13 unit tests |
| `apps/api/src/routes/activities.ts` | +POST /activities/upload (multipart) |
| `apps/api/src/routes/routes.integration.test.ts` | +3 tests de integración |
| `apps/api/src/app.ts` | Registro de @fastify/multipart (10MB max) |
| `docs/specs/L2-backend-07-import.md` | Spec técnica |

## Dependencias nuevas
- `@fastify/multipart` — manejo de uploads multipart
- `fit-file-parser` — parseo de archivos .fit (Garmin ANT+ protocol)
- `@we-gold/gpxjs` + `@xmldom/xmldom` — parseo de archivos .gpx

## Tests
- **130 tests API** (9 archivos) — 16 tests nuevos
- **278 tests totales** (130 api + 77 shared + 71 web)

## Test plan
- [x] CI backend pasa (lint + typecheck + tests)
- [x] CI frontend pasa (build + tests)
- [x] Endpoints existentes no afectados