### PR TITLE
feat: migrar frontend de Supabase directo a API backend (Bloque 8)

### DIFF
--- a/apps/web/src/app/(app)/activities/page.tsx
+++ b/apps/web/src/app/(app)/activities/page.tsx
@@ -1,13 +1,28 @@
-import { createClient } from "@/lib/supabase/server";
+import { apiGet, getServerToken } from "@/lib/api/server";
 import { ActivitiesContent } from "./activities-content";
 
+interface ActivityRow {
+  id: string;
+  name: string;
+  date: string;
+  type: string;
+  distance_km: number | null;
+  duration_seconds: number;
+  avg_power_watts: number | null;
+  avg_hr_bpm: number | null;
+  rpe: number | null;
+}
+
+interface ActivitiesResponse {
+  data: ActivityRow[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+}
+
 export default async function ActivitiesPage() {
-  const supabase = await createClient();
+  const token = await getServerToken();
+  if (!token) return null;
 
-  const { data: activities } = await supabase
-    .from("activities")
-    .select("id, name, date, type, distance_km, duration_seconds, avg_power_watts, avg_hr_bpm, rpe")
-    .order("date", { ascending: false });
+  const res = await apiGet<ActivitiesResponse>("/activities?limit=200", token);
 
-  return <ActivitiesContent activities={activities ?? []} />;
+  return <ActivitiesContent activities={res.data} />;
 }

--- a/apps/web/src/app/(app)/plan/plan-content.tsx
+++ b/apps/web/src/app/(app)/plan/plan-content.tsx
@@ -1,105 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, CalendarPlus } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, CalendarPlus, Loader2 } from "lucide-react";
 import type { PlanDay } from "shared";
+import { apiClientPost } from "@/lib/api/client";
 import { WeeklyLoadBar } from "@/components/weekly-load-bar";
 import { DayGrid } from "./day-grid";
 import { DayDetail } from "./day-detail";
-
-const MOCK_PLAN: PlanDay[] = [
-  {
-    day: "Lun",
-    date: "10",
-    type: "intervals",
-    title: "Intervalos 4x8'",
-    intensity: "alta",
-    duration: "1h30",
-    description: "4 series 8' Z4, 4' rec",
-    nutrition: "80g carbs antes. Gel mitad.",
-    rest: "Estiramientos 15min. Foam roller.",
-    done: true,
-    actual_power: 205,
-  },
-  {
-    day: "Mar",
-    date: "11",
-    type: "recovery",
-    title: "Recuperación activa",
-    intensity: "baja",
-    duration: "1h",
-    description: "Z1-Z2, cadencia >85rpm",
-    nutrition: "2L extra. Fruta post.",
-    rest: "Mín 8h sueño.",
-    done: true,
-    actual_power: 132,
-  },
-  {
-    day: "Mié",
-    date: "12",
-    type: "endurance",
-    title: "Resistencia Z2",
-    intensity: "media",
-    duration: "2h",
-    description: "Z2 constante",
-    nutrition: "2 bidones. Barrita 1h.",
-    rest: "Estiramientos. Cena proteínas.",
-    done: true,
-    actual_power: 168,
-  },
-  {
-    day: "Jue",
-    date: "13",
-    type: "rest",
-    title: "Descanso",
-    intensity: "—",
-    duration: "—",
-    description: "Descanso total",
-    nutrition: "No recortar calorías.",
-    rest: "Contraste frío/calor.",
-    done: true,
-    actual_power: null,
-  },
-  {
-    day: "Vie",
-    date: "14",
-    type: "tempo",
-    title: "Tempo sostenido",
-    intensity: "media-alta",
-    duration: "1h15",
-    description: "30' Z3 tras calentamiento",
-    nutrition: "Gel antes del bloque.",
-    rest: "Acostarse antes 23h.",
-    done: false,
-    actual_power: null,
-  },
-  {
-    day: "Sáb",
-    date: "15",
-    type: "endurance",
-    title: "Ruta larga Z2",
-    intensity: "media",
-    duration: "3h",
-    description: "Ritmo constante",
-    nutrition: "60g/h carbs. Avena antes.",
-    rest: "Siesta post.",
-    done: false,
-    actual_power: null,
-  },
-  {
-    day: "Dom",
-    date: "16",
-    type: "recovery",
-    title: "Rec./descanso",
-    intensity: "baja",
-    duration: "0-45min",
-    description: "Según sensaciones",
-    nutrition: "Comida equilibrada.",
-    rest: "Foam roller. Preparar semana.",
-    done: false,
-    actual_power: null,
-  },
-];
 
 interface PlanContentProps {
   serverPlanDays: PlanDay[] | null;
@@ -114,20 +21,38 @@ function getTodayIndex(days: PlanDay[]): number {
 }
 
 export function PlanContent({ serverPlanDays }: PlanContentProps) {
-  const planDays = serverPlanDays ?? MOCK_PLAN;
-  const hasPlan = planDays.length > 0;
-  const todayIndex = getTodayIndex(planDays);
+  const [planDays, setPlanDays] = useState<PlanDay[] | null>(serverPlanDays);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const hasPlan = planDays && planDays.length > 0;
+  const todayIndex = hasPlan ? getTodayIndex(planDays) : 0;
   const [selectedIndex, setSelectedIndex] = useState(todayIndex);
 
-  const selectedDay = planDays[selectedIndex];
+  const selectedDay = hasPlan ? planDays[selectedIndex] : null;
 
-  // TSS estimates based on mock data
+  // TSS estimates — placeholder, ideally from API insights
   const currentTSS = 320;
   const avgTSS = 380;
   const maxTSS = 550;
 
+  async function handleGeneratePlan(forceRegenerate = false) {
+    setIsGenerating(true);
+    try {
+      const res = await apiClientPost<{ data: { plan_data: PlanDay[] } }>("/ai/weekly-plan", {
+        force_regenerate: forceRegenerate,
+      });
+      if (res.data?.plan_data) {
+        setPlanDays(res.data.plan_data);
+        setSelectedIndex(getTodayIndex(res.data.plan_data));
+      }
+    } catch {
+      // Error generating plan
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
   if (!hasPlan) {
-    return <EmptyState />;
+    return <EmptyState onGenerate={() => handleGeneratePlan(false)} isGenerating={isGenerating} />;
   }
 
   return (
@@ -158,11 +83,16 @@ export function PlanContent({ serverPlanDays }: PlanContentProps) {
         </div>
 
         <button
-          onClick={() => alert("Funcionalidad próximamente")}
-          className="flex items-center gap-2 rounded-xl bg-gradient-to-r from-orange-500 to-orange-600 px-4 py-2 text-[13px] font-semibold text-white shadow-sm transition-opacity hover:opacity-90"
+          onClick={() => handleGeneratePlan(true)}
+          disabled={isGenerating}
+          className="flex items-center gap-2 rounded-xl bg-gradient-to-r from-orange-500 to-orange-600 px-4 py-2 text-[13px] font-semibold text-white shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50"
         >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Recalcular
+          {isGenerating ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3.5 w-3.5" />
+          )}
+          {isGenerating ? "Generando..." : "Recalcular"}
         </button>
       </div>
 
@@ -187,7 +117,13 @@ export function PlanContent({ serverPlanDays }: PlanContentProps) {
   );
 }
 
-function EmptyState() {
+function EmptyState({
+  onGenerate,
+  isGenerating,
+}: {
+  onGenerate: () => void;
+  isGenerating: boolean;
+}) {
   return (
     <div>
       <h1 className="mb-6 text-[22px] font-bold text-[var(--text-primary)] md:text-[26px]">
@@ -199,10 +135,12 @@ function EmptyState() {
           No hay plan generado para esta semana.
         </p>
         <button
-          onClick={() => alert("Funcionalidad próximamente")}
-          className="rounded-xl bg-gradient-to-r from-orange-500 to-orange-600 px-5 py-2.5 text-[13px] font-semibold text-white shadow-sm transition-opacity hover:opacity-90"
+          onClick={onGenerate}
+          disabled={isGenerating}
+          className="flex items-center gap-2 rounded-xl bg-gradient-to-r from-orange-500 to-orange-600 px-5 py-2.5 text-[13px] font-semibold text-white shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50"
         >
-          Generar mi primer plan
+          {isGenerating && <Loader2 className="h-4 w-4 animate-spin" />}
+          {isGenerating ? "Generando plan..." : "Generar mi primer plan"}
         </button>
       </div>
     </div>

--- a/apps/web/src/app/(app)/profile/profile-content.tsx
+++ b/apps/web/src/app/(app)/profile/profile-content.tsx
@@ -11,7 +11,7 @@ import { OnboardingField } from "@/components/onboarding-field";
 import { GoalCard } from "@/components/goal-card";
 import { ZoneTable } from "@/components/zone-table";
 import { ProfileHeader } from "./profile-header";
-import { createClient } from "@/lib/supabase/client";
+import { apiClientPatch } from "@/lib/api/client";
 
 interface ProfileContentProps {
   profile: {
@@ -84,10 +84,8 @@ export function ProfileContent({ profile }: ProfileContentProps) {
       return;
     }
 
-    const supabase = createClient();
-    const { error } = await supabase
-      .from("users")
-      .update({
+    try {
+      await apiClientPatch("/profile", {
         display_name: parsed.data.display_name,
         age: parsed.data.age,
         weight_kg: parsed.data.weight_kg,
@@ -95,14 +93,11 @@ export function ProfileContent({ profile }: ProfileContentProps) {
         max_hr: parsed.data.max_hr ?? null,
         rest_hr: parsed.data.rest_hr ?? null,
         goal: parsed.data.goal,
-      })
-      .eq("id", profile.id);
-
-    if (error) {
-      setErrors({ _form: "Error al guardar. Inténtalo de nuevo." });
-    } else {
+      });
       setOriginalData({ ...formData });
       router.refresh();
+    } catch {
+      setErrors({ _form: "Error al guardar. Inténtalo de nuevo." });
     }
 
     setIsSaving(false);

--- a/apps/web/src/components/file-drop-zone.tsx
+++ b/apps/web/src/components/file-drop-zone.tsx
@@ -7,6 +7,7 @@ export interface FileInfo {
   name: string;
   size: number;
   ext: string;
+  raw: File;
 }
 
 interface FileDropZoneProps {
@@ -18,7 +19,7 @@ interface FileDropZoneProps {
 function extractFileInfo(f: File): FileInfo | null {
   const ext = f.name.split(".").pop()?.toLowerCase();
   if (ext && ["fit", "gpx"].includes(ext)) {
-    return { name: f.name, size: f.size, ext };
+    return { name: f.name, size: f.size, ext, raw: f };
   }
   return null;
 }

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,0 +1,64 @@
+import { createClient } from "@/lib/supabase/client";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+/**
+ * Fetch del API backend desde Client Components.
+ * Obtiene el token de la sesión de Supabase en el browser.
+ */
+export async function apiClientFetch<T>(
+  path: string,
+  method: string = "GET",
+  body?: unknown,
+): Promise<T> {
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.access_token) {
+    throw new Error("No authenticated session");
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${session.access_token}`,
+  };
+
+  if (body && !(body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await fetch(`${API_URL}/api/v1${path}`, {
+    method,
+    headers,
+    body: body instanceof FormData ? body : body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "Unknown error");
+    throw new Error(`API ${res.status}: ${text}`);
+  }
+
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+/** Shorthand para POST desde Client Components */
+export function apiClientPost<T>(path: string, body: unknown): Promise<T> {
+  return apiClientFetch<T>(path, "POST", body);
+}
+
+/** Shorthand para PATCH desde Client Components */
+export function apiClientPatch<T>(path: string, body: unknown): Promise<T> {
+  return apiClientFetch<T>(path, "PATCH", body);
+}
+
+/** Shorthand para DELETE desde Client Components */
+export function apiClientDelete<T>(path: string): Promise<T> {
+  return apiClientFetch<T>(path, "DELETE");
+}
+
+/** Upload de archivo multipart desde Client Components */
+export async function apiClientUpload<T>(path: string, formData: FormData): Promise<T> {
+  return apiClientFetch<T>(path, "POST", formData);
+}

--- a/apps/web/src/lib/api/server.ts
+++ b/apps/web/src/lib/api/server.ts
@@ -1,0 +1,33 @@
+import { createClient } from "@/lib/supabase/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+/**
+ * Obtener token de sesión Supabase desde Server Components.
+ * Usa el cliente de Supabase SSR para acceder a la sesión del usuario.
+ */
+export async function getServerToken(): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return session?.access_token ?? null;
+}
+
+/**
+ * Fetch del API backend desde Server Components.
+ * Recibe el token JWT de Supabase Auth para autenticación.
+ */
+export async function apiGet<T>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${API_URL}/api/v1${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "Unknown error");
+    throw new Error(`API ${res.status}: ${text}`);
+  }
+
+  return res.json() as Promise<T>;
+}

--- a/docs/01-PRODUCT-VISION.md
+++ b/docs/01-PRODUCT-VISION.md
@@ -211,7 +211,7 @@ El protagonista es el **pipeline AI-first**. El producto es el terreno donde se 
 
 > Última actualización: 2026-02-15
 
-### Pantallas implementadas (Fase 1 completada)
+### Frontend (Fase 2 completada ✅)
 
 | Pantalla | Estado | Notas |
 |----------|--------|-------|
@@ -224,16 +224,31 @@ El protagonista es el **pipeline AI-first**. El producto es el terreno donde se 
 | Planificación semanal | ✅ Implementada (Fase 2) | Vista semanal, sugerencias IA, recomendaciones |
 | Insights / Comparar | ✅ Implementada (Fase 2) | Comparativas, radar, análisis tendencias |
 
+### Backend API (Fase 3 — Bloques 0-7 completados ✅)
+
+| Bloque | Endpoints | Estado |
+|--------|-----------|--------|
+| 0 — Infraestructura | `/health`, plugins (auth, cors, errors, env) | ✅ |
+| 1 — Perfil | `GET/PATCH /api/v1/profile` | ✅ |
+| 2 — Actividades | `GET/POST/PATCH/DELETE /api/v1/activities`, `GET /activities/:id/metrics` | ✅ |
+| 3 — Insights | `GET /api/v1/insights`, `GET /api/v1/insights/overload-check` | ✅ |
+| 4 — Training Rules | Cálculos CTL/ATL/TSB, alertas, zonas en `packages/shared` | ✅ |
+| 5 — IA (Claude API) | `POST /api/v1/ai/analyze-activity`, `POST /ai/weekly-plan`, `POST /ai/weekly-summary`, `GET /ai/coach-tip` | ✅ |
+| 6 — Weekly Plan | `GET/PATCH/DELETE /api/v1/plan` | ✅ |
+| 7 — Import | `POST /api/v1/activities/upload` (.fit/.gpx) | ✅ |
+
 ### Artefactos de diseño y especificación
 
 - **Design System**: `docs/DESIGN-SYSTEM.md` — guía completa con tokens, componentes, paleta y guía de conversión JSX→Next.js
 - **Mockups JSX**: `docs/design/` — fuente de verdad visual (excluidos de git)
-- **Especificaciones**: 22 archivos en `docs/specs/` (L1 funcional, L2 técnico, L3 plan de issues) para las 8 pantallas
-- **Schemas compartidos**: `packages/shared/src/` — validaciones Zod y constantes de negocio
+- **Especificaciones**: 22 archivos L1/L2/L3 (frontend) + 8 archivos L2-backend (API) en `docs/specs/`
+- **Schemas compartidos**: `packages/shared/src/` — 5 schemas Zod + 7 módulos de constantes + utils de training
 
 ### Infraestructura
 
 - Monorepo Turborepo + pnpm operativo
-- CI/CD: GitHub Actions (lint, typecheck, format, build)
-- Base de datos: Supabase con 4 tablas + RLS + 2 migraciones aplicadas
+- CI/CD: GitHub Actions separados (frontend + backend)
+- Base de datos: Supabase con 5 tablas + RLS + 4 migraciones aplicadas
 - Auth: Google OAuth via Supabase Auth
+- Deploy: Vercel (frontend) + Render (API) + Supabase (DB)
+- Tests: 27 archivos, 278 tests (71 web + 77 shared + 130 API)

--- a/docs/03-AGENTS-AND-DEVELOPMENT-PLAN.md
+++ b/docs/03-AGENTS-AND-DEVELOPMENT-PLAN.md
@@ -372,16 +372,16 @@ jobs:
 
 ## 3. Resumen de agentes
 
-| ID  | Nombre         | Tipo   | Trigger                | Fase     | Estado (2026-02-14) |
+| ID  | Nombre         | Tipo   | Trigger                | Fase     | Estado (2026-02-15) |
 | --- | -------------- | ------ | ---------------------- | -------- | ------------------- |
 | L1  | UX Interpreter | Local  | Manual                 | Fase 1   | ✅ Usado (8 pantallas) |
-| L2  | Architect      | Local  | Manual                 | Fase 1   | ✅ Usado (8 pantallas) |
+| L2  | Architect      | Local  | Manual                 | Fase 1-3 | ✅ Usado (8 pantallas + 8 bloques backend) |
 | L3  | Planner        | Local  | Manual                 | Fase 1-2 | ✅ Usado (6 pantallas) |
-| L4  | Implementer    | Local  | Manual                 | Fase 1   | ✅ Usado (6 pantallas implementadas) |
+| L4  | Implementer    | Local  | Manual                 | Fase 1-3 | ✅ Usado (8 pantallas + 8 bloques backend) |
 | R1  | Issue Analyzer | Remoto | Label `ai-analyze`     | Fase 2   | ⏳ Pendiente |
 | R2  | PR Generator   | Remoto | Label `ai-generate-pr` | Fase 3   | ⏳ Pendiente |
 | R3  | PR Reviewer    | Remoto | PR abierta             | Fase 2   | ⏳ Pendiente |
-| R4  | CI/CD          | Remoto | Push/PR                | Fase 1   | ✅ Activo (ci.yml) |
+| R4  | CI/CD          | Remoto | Push/PR                | Fase 1   | ✅ Activo (ci-frontend.yml + ci-backend.yml) |
 | R5  | Doc Generator  | Remoto | PR mergeada            | Fase 3   | ⏳ Pendiente |
 
 ---
@@ -390,12 +390,12 @@ jobs:
 
 El desarrollo se organiza en **4 fases** distribuidas en **7 semanas**, diseñado para ganar confianza y experiencia de forma progresiva.
 
-### Estado actual (2026-02-14)
+### Estado actual (2026-02-15)
 
 ```
 Fase 1: Cimientos                    ✅ COMPLETADA
-Fase 2: MVP funcional                🔄 EN PROGRESO (pantallas 05 y 07 pendientes)
-Fase 3: Pipeline AI-first            ⏳ PENDIENTE
+Fase 2: MVP funcional (frontend)     ✅ COMPLETADA
+Fase 3: Backend + IA                 🔄 EN PROGRESO (Bloques 0-7 completados, Bloque 8 pendiente)
 Fase 4: Pulido y evaluación          ⏳ PENDIENTE
 ```
 
@@ -507,7 +507,7 @@ Fase 4: Pulido y evaluación (métricas + documentación)
 - ✅ Planificación semanal (implementada)
 - ✅ Comparativa de semanas / Insights (implementada)
 - ✅ Perfil editable (implementado)
-- ⏳ Alertas de sobrecarga (pendiente)
+- ✅ Alertas de sobrecarga (implementado en backend: `insights/overload-check` + reglas en shared)
 - ✅ **MVP frontend completado**: todas las pantallas (0-7) implementadas
 
 **Frontend status**: 🎉 Fase 2 completada. Todos los componentes, rutas y pantallas funcionales con datos Supabase y mock data.
@@ -516,21 +516,44 @@ Fase 4: Pulido y evaluación (métricas + documentación)
 
 ---
 
-### FASE 3 — Pipeline AI-First Completo (Semanas 5-6)
+### FASE 3 — Backend + IA + Pipeline AI-First (Semanas 5-6)
 
-**Objetivo**: Activar todos los agentes remotos. Generar features nuevas vía PRs automáticas. Esta es la fase central del proyecto.
+**Objetivo**: Implementar backend completo, integrar Claude API, migrar frontend a API. Activar agentes remotos.
 
-#### Semana 5: Agentes remotos completos
+#### Semana 5: Backend API completo (Bloques 0-7) ✅ COMPLETADA
+
+| Bloque | Tarea | Estado |
+| ------ | ----- | ------ |
+| 0 | Infraestructura: env, cors, auth, error-handler, supabase, anthropic | ✅ |
+| 1 | Profile: GET/PATCH /api/v1/profile | ✅ |
+| 2 | Activities: CRUD /api/v1/activities + metrics | ✅ |
+| 3 | Insights: GET /api/v1/insights + overload-check | ✅ |
+| 4 | Training Rules: calculateTrainingLoad, evaluateTrainingAlerts en shared | ✅ |
+| 5 | IA (Claude API): 4 endpoints /api/v1/ai/* con cache, fallback, rate limit | ✅ |
+| 6 | Weekly Plan: GET/PATCH/DELETE /api/v1/plan | ✅ |
+| 7 | Import: POST /api/v1/activities/upload (.fit/.gpx) | ✅ |
+
+**Entregables semana 5**: ✅ COMPLETADOS
+- ✅ API Fastify con 15+ endpoints funcionales
+- ✅ 4 endpoints IA con Claude API, caché, fallback y rate limiting
+- ✅ Importación real de archivos .fit/.gpx
+- ✅ 130 tests API + 77 tests shared (207 total backend)
+- ✅ 4 migraciones SQL aplicadas
+- ✅ 8 specs L2-backend generadas
+- ✅ Deploy en producción (Render)
+
+#### Semana 6: Frontend migration + Agentes remotos
 
 | Día | Tarea                                                           | Agente       |
 | --- | --------------------------------------------------------------- | ------------ |
-| 1   | Configurar agente R2 (PR Generator)                             | Manual       |
-| 1   | Probar flujo completo: issue → ai-analyze → ai-generate-pr → PR | R1 + R2      |
-| 2   | Configurar agente R5 (Doc Generator)                            | Manual       |
-| 2   | Probar: merge → changelog automático                            | R5           |
-| 3   | Crear 3-5 issues de features secundarias para probar pipeline   | L3           |
-| 3   | Ejecutar pipeline completo en 1-2 features                      | R1 + R2 + R3 |
-| 4   | Comparar: PR generada por IA vs PR manual (misma feature)       | Evaluación   |
+| 1   | Bloque 8: Migrar frontend de Supabase directo → API backend     | L4           |
+| 2   | Configurar agente R2 (PR Generator)                             | Manual       |
+| 2   | Probar flujo completo: issue → ai-analyze → ai-generate-pr → PR | R1 + R2      |
+| 3   | Configurar agente R5 (Doc Generator)                            | Manual       |
+| 3   | Probar: merge → changelog automático                            | R5           |
+| 4   | Crear 3-5 issues de features secundarias para probar pipeline   | L3           |
+| 4   | Ejecutar pipeline completo en 1-2 features                      | R1 + R2 + R3 |
+| 5   | Comparar: PR generada por IA vs PR manual (misma feature)       | Evaluación   |
 | 5   | Documentar flujos, ajustar prompts, versionar prompts           | Manual       |
 
 **Features secundarias sugeridas para probar el pipeline**:
@@ -541,21 +564,15 @@ Fase 4: Pulido y evaluación (métricas + documentación)
 4. Dark mode toggle
 5. Estadísticas de "mejor semana" en el dashboard
 
-#### Semana 6: Iteración y refinamiento
-
-| Día | Tarea                                                 | Agente            |
-| --- | ----------------------------------------------------- | ----------------- |
-| 1-2 | Ejecutar 2-3 features más vía pipeline completo       | Pipeline completo |
-| 3   | Refinar prompts basándose en calidad de PRs generadas | Manual            |
-| 4   | Implementar modo "IA desactivada" para comparativa    | Manual            |
-| 5   | Recopilar métricas de todo el proceso                 | Manual            |
-
 **Entregables fase 3**:
 
-- Pipeline AI-first funcionando end-to-end
-- 5-8 features añadidas vía PRs automáticas
-- Comparativa pipeline tradicional vs AI-first
-- Prompts versionados y documentados
+- ✅ Backend API completo con 15+ endpoints
+- ✅ 4 endpoints IA con Claude API (cache + fallback + rate limit)
+- ✅ Importación real .fit/.gpx
+- ✅ 278 tests (27 archivos): 71 web + 77 shared + 130 API
+- ⏳ Frontend migrado a API backend (Bloque 8)
+- ⏳ Pipeline AI-first end-to-end
+- ⏳ Comparativa pipeline tradicional vs AI-first
 
 ---
 
@@ -790,16 +807,16 @@ Para los agentes R1 y R2 que usan Claude, hay dos opciones:
 
 ## 10. Checklist de arranque
 
-> Estado actualizado: 2026-02-14
+> Estado actualizado: 2026-02-15
 
-- [x] Crear proyecto en Supabase (con 2 migraciones aplicadas)
+- [x] Crear proyecto en Supabase (con 4 migraciones aplicadas)
 - [x] Configurar Google OAuth en Google Cloud Console + Supabase (ref: `docs/GOOGLE-OAUTH-SETUP.md`)
 - [x] Crear repo en GitHub
 - [x] Cuenta en Vercel conectada al repo
-- [ ] Cuenta en Render conectada al repo
-- [ ] API key de Anthropic (para agentes remotos y entrenador IA)
+- [x] Cuenta en Render conectada al repo (deploy producción activo)
+- [x] API key de Anthropic (para agentes remotos y entrenador IA)
 - [x] Preparar mockups JSX en `docs/design/` y documentar en `docs/DESIGN-SYSTEM.md`
 - [x] Crear archivo `CLAUDE.md` con convenciones del proyecto
 - [x] Tener este documento y el PRD accesibles en `/docs/`
 - [x] Configurar ESLint 9 + Prettier + Turborepo
-- [x] CI pipeline básico (GitHub Actions: lint, typecheck, format, build)
+- [x] CI pipeline (GitHub Actions: ci-frontend.yml + ci-backend.yml)

--- a/docs/specs/L2-backend-08-frontend-migration.md
+++ b/docs/specs/L2-backend-08-frontend-migration.md
@@ -1,0 +1,135 @@
+# L2 — Bloque 8: Frontend Migration (Supabase directo → API Backend)
+
+## Contexto
+
+El frontend (Next.js) accede actualmente a Supabase de forma directa desde Server Components y Client Components.
+El backend Fastify ya tiene todos los endpoints implementados (Bloques 0-7). Este bloque migra el frontend
+para consumir datos vía la API, manteniendo la autenticación vía Supabase Auth (JWT) y el patrón SSR de Next.js.
+
+## Estado Actual
+
+| Página | Lectura | Escritura | Fuente actual |
+|--------|---------|-----------|---------------|
+| Dashboard `/` | users, activities (4 semanas) | — | Supabase directo (Server) |
+| Activities `/activities` | activities (lista) | — | Supabase directo (Server) |
+| Activity Detail `/activities/[id]` | activities, activity_metrics | — | Supabase directo (Server) |
+| Import `/activities/import` | — | activities (INSERT) | Supabase directo (Client) |
+| Plan `/plan` | weekly_plans | — | Supabase directo (Server) + mock fallback |
+| Insights `/insights` | activities (2 periodos) | — | Supabase directo (Server) |
+| Profile `/profile` | users | users (UPDATE) | Supabase directo (Server + Client) |
+| Onboarding `/onboarding` | users (check) | users (INSERT) | Supabase directo (Server + Client) |
+| Login `/auth/login` | auth.getUser() | — | Supabase Auth (mantener) |
+
+## Decisiones Arquitectónicas
+
+| Decisión | Elección | Rationale |
+|----------|----------|-----------|
+| Auth | Mantener Supabase Auth SSR en frontend | El JWT de Supabase se reutiliza como Bearer token al API |
+| Server fetch | `fetch()` en Server Components con `Authorization: Bearer {token}` | Misma seguridad, datos vienen del API |
+| Client fetch | `fetch()` en Client Components con token de sesión | Reemplaza `createBrowserClient` para escrituras |
+| API URL | `NEXT_PUBLIC_API_URL` (ya configurado, sin usar) | Ya existe en `.env.example` |
+| Cálculos locales | Mantener en frontend donde el API no provee equivalente | Dashboard KPIs, trends — calcular sobre datos de API |
+| Plan mock fallback | Eliminar — usar API endpoint `/api/v1/plan` | La API ya genera plan con IA |
+| IA coach tip | Nuevo — consumir `GET /api/v1/ai/coach-tip` | Reemplaza recomendación hardcoded en Dashboard |
+| Onboarding | Mantener Supabase directo | No hay endpoint de creación de usuario en API (se crea vía Supabase Auth + trigger) |
+
+## Helper: API Client
+
+Crear `apps/web/src/lib/api/client.ts` — utilidad para llamadas al API backend.
+
+```typescript
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+// Para Server Components (recibe token explícitamente)
+export async function apiGet<T>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${API_URL}/api/v1${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`API ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// Para Client Components (obtiene token de sesión)
+export async function apiClientFetch<T>(
+  path: string, method: string, body?: unknown
+): Promise<T> { ... }
+```
+
+## Migración por Página
+
+### 1. Dashboard (`/`)
+**Antes**: `supabase.from("users")` + `supabase.from("activities")`
+**Después**: `apiGet("/profile", token)` + `apiGet("/activities?date_from=...&limit=100", token)` + `apiGet("/ai/coach-tip", token)` (nuevo: coach IA real)
+**Archivos**: `apps/web/src/app/(app)/page.tsx`
+**Nota**: Los cálculos de KPIs/trends se mantienen en `lib/dashboard/calculations.ts` operando sobre datos del API
+
+### 2. Lista de Actividades (`/activities`)
+**Antes**: `supabase.from("activities").select(...).order("date")`
+**Después**: `apiGet("/activities?page=1&limit=50", token)`
+**Archivos**: `apps/web/src/app/(app)/activities/page.tsx`
+**Nota**: El API ya soporta paginación, filtros (type, date_from, date_to, search)
+
+### 3. Detalle de Actividad (`/activities/[id]`)
+**Antes**: `supabase.from("activities")` + `supabase.from("activity_metrics")`
+**Después**: `apiGet("/activities/{id}", token)` + `apiGet("/activities/{id}/metrics", token)`
+**Archivos**: `apps/web/src/app/(app)/activities/[id]/page.tsx`
+
+### 4. Importar Actividad (`/activities/import`)
+**Antes**: Client Component → `supabase.from("activities").insert(payload)` (solo modo manual)
+**Después (manual)**: `apiClientPost("/activities", payload)`
+**Después (archivo)**: `apiClientUpload("/activities/upload", formData)` — multipart
+**Archivos**: `apps/web/src/app/(app)/activities/import/import-activity-content.tsx`
+**Nota**: Habilitar modo archivo real (actualmente placeholder)
+
+### 5. Plan Semanal (`/plan`)
+**Antes**: `supabase.from("weekly_plans")` + MOCK_PLAN fallback
+**Después**: `apiGet("/plan?week_start=...", token)` — si 404, mostrar botón "Generar plan"
+**Generar**: `apiClientPost("/ai/weekly-plan", { week_start })` — crea plan con IA
+**Archivos**: `apps/web/src/app/(app)/plan/page.tsx`, `plan-content.tsx`
+**Nota**: Eliminar MOCK_PLAN. El API `/ai/weekly-plan` genera y persiste.
+
+### 6. Insights (`/insights`)
+**Antes**: `supabase.from("activities")` con 2 queries por periodo
+**Después**: `apiGet("/insights?period_a_start=...&period_a_end=...&period_b_start=...&period_b_end=...", token)`
+**Archivos**: `apps/web/src/app/(app)/insights/page.tsx`
+**Nota**: El API ya calcula comparativas, CTL/ATL/TSB, alertas
+
+### 7. Perfil (`/profile`)
+**Lectura**: `apiGet("/profile", token)` (Server Component)
+**Escritura**: `apiClientPatch("/profile", data)` (Client Component)
+**Archivos**: `apps/web/src/app/(app)/profile/page.tsx`, `profile-content.tsx`
+
+### 8. Onboarding (`/onboarding`)
+**Mantener** Supabase directo para INSERT de usuario — coherente con Supabase Auth flow.
+No hay endpoint API para crear usuario (se crea automáticamente vía Auth trigger + onboarding form).
+
+### 9. Login (`/auth/login`)
+**Mantener** Supabase Auth directo — no cambia.
+
+## Archivos
+
+| # | Archivo | Acción |
+|---|---------|--------|
+| 1 | `apps/web/src/lib/api/client.ts` | **Crear** — API client helper (server + client) |
+| 2 | `apps/web/src/app/(app)/page.tsx` | **Modificar** — Dashboard: API fetch + coach tip real |
+| 3 | `apps/web/src/app/(app)/activities/page.tsx` | **Modificar** — Lista: API fetch |
+| 4 | `apps/web/src/app/(app)/activities/[id]/page.tsx` | **Modificar** — Detalle: API fetch |
+| 5 | `apps/web/src/app/(app)/activities/import/import-activity-content.tsx` | **Modificar** — Import: API POST + upload |
+| 6 | `apps/web/src/app/(app)/plan/page.tsx` | **Modificar** — Plan: API fetch |
+| 7 | `apps/web/src/app/(app)/plan/plan-content.tsx` | **Modificar** — Eliminar MOCK_PLAN, generar via API |
+| 8 | `apps/web/src/app/(app)/insights/page.tsx` | **Modificar** — Insights: API fetch |
+| 9 | `apps/web/src/app/(app)/profile/page.tsx` | **Modificar** — Profile read: API fetch |
+| 10 | `apps/web/src/app/(app)/profile/profile-content.tsx` | **Modificar** — Profile write: API PATCH |
+
+## Tests
+
+- API client: fetch mock → respuesta correcta, error handling
+- Integración: verificar que las páginas renderizan con datos de API (E2E futuro)
+
+## Notas
+
+- La autenticación Supabase SSR se mantiene intacta para `auth.getUser()` y protección de rutas en `layout.tsx`
+- El token JWT de Supabase se pasa como `Authorization: Bearer` header al API backend
+- `NEXT_PUBLIC_API_URL` ya está configurado en `.env.example` pero no se usa — este bloque lo activa
+- Los cálculos locales del dashboard (`lib/dashboard/calculations.ts`) se mantienen — no hay endpoint equivalente en API


### PR DESCRIPTION
## Summary

- **Bloque 8 — Frontend Migration**: Migrar todas las páginas de acceso directo a Supabase a llamadas al API backend con autenticación JWT Bearer
- Crear API client helpers separados para Server y Client Components (`lib/api/server.ts` y `lib/api/client.ts`)
- Migrar 9 páginas/componentes: Dashboard, Activities (list/detail), Profile (read/write), Insights, Plan (read/generate), Import (manual/archivo)
- Eliminar mock data (MOCK_PLAN), conectar botones de generación/recalcular plan a API real
- Actualizar documentación (VISION, PRD, AGENTS, README, CLAUDE.md) con estado Bloques 0-7

## Cambios por página

| Página | Antes | Después |
|--------|-------|---------|
| Dashboard | `supabase.from("users/activities")` | `apiGet("/profile")` + `apiGet("/activities")` + `apiGet("/insights/overload-check")` + `apiGet("/ai/coach-tip")` |
| Activities list | `supabase.from("activities")` | `apiGet("/activities?limit=200")` |
| Activity detail | `supabase.from("activities/activity_metrics")` | `apiGet("/activities/:id")` + `apiGet("/activities/:id/metrics")` |
| Profile read | `supabase.from("users")` | `apiGet("/profile")` |
| Profile write | `supabase.from("users").update()` | `apiClientPatch("/profile")` |
| Insights | `supabase.from("activities")` + local calc | `apiGet("/insights?periods...")` (API calcula todo) |
| Plan read | Mock data | `apiGet("/plan?week_start=...")` |
| Plan generate | N/A | `apiClientPost("/ai/weekly-plan")` |
| Import | `supabase.from("activities").insert()` | `apiClientPost("/activities")` + `apiClientUpload("/activities/upload")` |

## Decisiones arquitectónicas

- **Split server/client**: `server.ts` usa `cookies()` vía Supabase SSR; `client.ts` usa `createClient()` del browser. Separados porque Turbopack traza dynamic imports y falla si un Client Component importa indirectamente `next/headers`
- **Auth preservada**: Supabase Auth SSR se mantiene en `layout.tsx`/middleware para route guards; el JWT se reutiliza como Bearer token para la API
- **Onboarding no migrado**: No existe endpoint API de creación de usuario (se crea via trigger de Supabase Auth)

## Test plan

- [x] `pnpm --filter web typecheck` — PASS
- [x] `pnpm --filter web test` — 71/71 PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm build` — PASS
- [x] `pnpm test` — 278/278 PASS (shared 77 + api 130 + web 71)
- [ ] Test manual: login → dashboard muestra datos reales de API
- [ ] Test manual: import archivo .fit → actividad creada vía API
- [ ] Test manual: plan → generar/recalcular via AI endpoint