### PR TITLE
feat: añadir constante RPE_DESCRIPTIONS en packages/shared

### DIFF
--- a/packages/shared/src/constants/rpe.test.ts
+++ b/packages/shared/src/constants/rpe.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { RPE_COLORS, getRPEColor } from "./rpe";
+import { RPE_DESCRIPTIONS, RPE_COLORS, getRPEColor } from "./rpe";
+
+describe("RPE_DESCRIPTIONS", () => {
+  it("tiene exactamente 10 entradas (RPE 1-10)", () => {
+    expect(Object.keys(RPE_DESCRIPTIONS)).toHaveLength(10);
+  });
+
+  it("contiene claves del 1 al 10", () => {
+    for (let i = 1; i <= 10; i++) {
+      expect(RPE_DESCRIPTIONS[i]).toBeDefined();
+    }
+  });
+
+  it("cada descripción es un string no vacío", () => {
+    for (let i = 1; i <= 10; i++) {
+      expect(typeof RPE_DESCRIPTIONS[i]).toBe("string");
+      expect(RPE_DESCRIPTIONS[i].length).toBeGreaterThan(0);
+    }
+  });
+});
 
 describe("RPE_COLORS", () => {
   it("tiene 4 rangos definidos", () => {

--- a/packages/shared/src/constants/rpe.ts
+++ b/packages/shared/src/constants/rpe.ts
@@ -1,3 +1,16 @@
+export const RPE_DESCRIPTIONS: Record<number, string> = {
+  1: "Reposo total",
+  2: "Muy ligero, apenas esfuerzo",
+  3: "Ligero, respiración cómoda",
+  4: "Moderado-ligero, conversación fácil",
+  5: "Moderado, respiración más notable",
+  6: "Moderado-alto, conversación difícil",
+  7: "Alto, esfuerzo sostenido",
+  8: "Muy alto, difícil mantener el ritmo",
+  9: "Máximo, al límite",
+  10: "Esfuerzo total, sprint máximo",
+};
+
 export const RPE_COLORS = {
   low: { range: [1, 3], color: "#22c55e", label: "Bajo" },
   moderate: { range: [4, 6], color: "#eab308", label: "Moderado" },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,7 +30,7 @@ export {
   type CalculatedZone,
 } from "./constants/zones";
 export { ACTIVITY_FILTERS, type ActivityFilterKey } from "./constants/activity-filters";
-export { RPE_COLORS, getRPEColor } from "./constants/rpe";
+export { RPE_DESCRIPTIONS, RPE_COLORS, getRPEColor } from "./constants/rpe";
 export { INTENSITY_LEVELS, type IntensityLevel } from "./constants/intensity-levels";
 export { WEATHER_TYPES, type WeatherTypeKey } from "./constants/weather";
 


### PR DESCRIPTION
## Summary
- Añade `RPE_DESCRIPTIONS` (`Record<number, string>`) en `packages/shared/src/constants/rpe.ts`
- Descripciones en español para valores RPE 1-10
- Tests unitarios: 3 tests nuevos (10 entradas, claves 1-10, strings no vacíos)
- Re-export en `packages/shared/src/index.ts`

## Test plan
- [x] `pnpm --filter shared test` — 90 tests passed
- [x] `pnpm --filter shared lint` — sin errores
- [x] `pnpm --filter shared typecheck` — sin errores

Closes #12

---
> 🤖 PR generada por R2 (PR Generator) — `claude-sonnet-4-5-20250929` *(mock manual)*