### PR TITLE
fix: corregir CI workflows usando turbo run para respetar pipeline de dependencias

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -39,16 +39,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint backend
-        run: pnpm --filter api --filter shared lint
+        run: turbo run lint --filter=api --filter=shared
 
       - name: Type check backend
-        run: pnpm --filter api --filter shared typecheck
+        run: turbo run typecheck --filter=api --filter=shared
 
-      - name: Format check backend
-        run: pnpm --filter api --filter shared format:check
+      - name: Format check
+        run: pnpm format:check
 
       - name: Test backend
-        run: pnpm --filter api --filter shared test
+        run: turbo run test --filter=api --filter=shared
 
       - name: Build backend
-        run: pnpm --filter api build
+        run: turbo run build --filter=api

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -39,19 +39,19 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint frontend
-        run: pnpm --filter web --filter shared lint
+        run: turbo run lint --filter=web --filter=shared
 
       - name: Type check frontend
-        run: pnpm --filter web --filter shared typecheck
+        run: turbo run typecheck --filter=web --filter=shared
 
-      - name: Format check frontend
-        run: pnpm --filter web --filter shared format:check
+      - name: Format check
+        run: pnpm format:check
 
       - name: Test frontend
-        run: pnpm --filter web --filter shared test
+        run: turbo run test --filter=web --filter=shared
 
       - name: Build frontend
-        run: pnpm --filter web build
+        run: turbo run build --filter=web
         env:
           # Variables de entorno necesarias para el build de Next.js
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}

--- a/README.md
+++ b/README.md
@@ -300,17 +300,17 @@ cycling-companion/
 
 ### Pantallas Implementadas
 
-| Ruta                 | Pantalla      | Descripción                                                       | Fuente de datos            |
-| -------------------- | ------------- | ----------------------------------------------------------------- | -------------------------- |
-| `/auth/login`        | Login         | Autenticación con Google OAuth                                    | Supabase Auth              |
-| `/onboarding`        | Onboarding    | Wizard de 4 pasos: perfil → objetivos → zonas → resumen           | API backend                |
-| `/`                  | Dashboard     | KPIs, gráficas de potencia/carga, coach IA, últimas actividades   | API backend                |
-| `/activities`        | Lista         | Tabla paginada con filtros por tipo y búsqueda por nombre         | API backend                |
-| `/activities/[id]`   | Detalle       | Métricas, gráficas temporales (potencia/FC/cadencia), análisis IA | API backend                |
-| `/activities/import` | Importar      | Entrada manual o subida de archivo (.fit/.gpx)                    | API backend                |
-| `/plan`              | Planificación | Grid semanal (7 días), tips nutrición/descanso, barra de carga    | API backend                |
-| `/insights`          | Insights      | Comparativa entre periodos, radar de rendimiento, análisis IA     | API backend                |
-| `/profile`           | Perfil        | Datos personales, zonas potencia/FC, ajustes tema/unidades        | API backend                |
+| Ruta                 | Pantalla      | Descripción                                                       | Fuente de datos |
+| -------------------- | ------------- | ----------------------------------------------------------------- | --------------- |
+| `/auth/login`        | Login         | Autenticación con Google OAuth                                    | Supabase Auth   |
+| `/onboarding`        | Onboarding    | Wizard de 4 pasos: perfil → objetivos → zonas → resumen           | API backend     |
+| `/`                  | Dashboard     | KPIs, gráficas de potencia/carga, coach IA, últimas actividades   | API backend     |
+| `/activities`        | Lista         | Tabla paginada con filtros por tipo y búsqueda por nombre         | API backend     |
+| `/activities/[id]`   | Detalle       | Métricas, gráficas temporales (potencia/FC/cadencia), análisis IA | API backend     |
+| `/activities/import` | Importar      | Entrada manual o subida de archivo (.fit/.gpx)                    | API backend     |
+| `/plan`              | Planificación | Grid semanal (7 días), tips nutrición/descanso, barra de carga    | API backend     |
+| `/insights`          | Insights      | Comparativa entre periodos, radar de rendimiento, análisis IA     | API backend     |
+| `/profile`           | Perfil        | Datos personales, zonas potencia/FC, ajustes tema/unidades        | API backend     |
 
 ### Características Principales
 
@@ -397,16 +397,16 @@ Internamente implementado con:
 
 ## Documentación
 
-| Documento                                                                   | Descripción                                                             |
-| --------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| [01-PRODUCT-VISION.md](docs/01-PRODUCT-VISION.md)                           | Visión del producto, propuesta de valor, persona objetivo               |
-| [02-PRD.md](docs/02-PRD.md)                                                 | PRD completo: modelo de datos, endpoints, flujo IA, specs               |
-| [03-AGENTS-AND-DEVELOPMENT-PLAN.md](docs/03-AGENTS-AND-DEVELOPMENT-PLAN.md) | Plan de agentes locales y remotos, timeline de desarrollo               |
-| [DESIGN-SYSTEM.md](docs/DESIGN-SYSTEM.md)                                   | Design system: pantallas, tokens, componentes, conversión JSX→Next.js   |
-| [GOOGLE-OAUTH-SETUP.md](docs/GOOGLE-OAUTH-SETUP.md)                         | Guía de configuración de Google OAuth en Supabase                       |
-| [SUPABASE-SETUP.md](docs/SUPABASE-SETUP.md)                                 | Guía de configuración de Supabase y base de datos                       |
-| [CLAUDE.md](CLAUDE.md)                                                      | Instrucciones para Claude Code (este repositorio)                       |
-| `docs/specs/`                                                               | 27 especificaciones L1/L2/L3 (8 pantallas + 9 bloques backend) |
+| Documento                                                                   | Descripción                                                           |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [01-PRODUCT-VISION.md](docs/01-PRODUCT-VISION.md)                           | Visión del producto, propuesta de valor, persona objetivo             |
+| [02-PRD.md](docs/02-PRD.md)                                                 | PRD completo: modelo de datos, endpoints, flujo IA, specs             |
+| [03-AGENTS-AND-DEVELOPMENT-PLAN.md](docs/03-AGENTS-AND-DEVELOPMENT-PLAN.md) | Plan de agentes locales y remotos, timeline de desarrollo             |
+| [DESIGN-SYSTEM.md](docs/DESIGN-SYSTEM.md)                                   | Design system: pantallas, tokens, componentes, conversión JSX→Next.js |
+| [GOOGLE-OAUTH-SETUP.md](docs/GOOGLE-OAUTH-SETUP.md)                         | Guía de configuración de Google OAuth en Supabase                     |
+| [SUPABASE-SETUP.md](docs/SUPABASE-SETUP.md)                                 | Guía de configuración de Supabase y base de datos                     |
+| [CLAUDE.md](CLAUDE.md)                                                      | Instrucciones para Claude Code (este repositorio)                     |
+| `docs/specs/`                                                               | 27 especificaciones L1/L2/L3 (8 pantallas + 9 bloques backend)        |
 
 ---
 
@@ -425,14 +425,14 @@ Este proyecto implementa un pipeline multi-agente para integrar IA en el ciclo d
 
 ### Agentes Remotos (GitHub Actions + `claude-code-action@v1`) — Activos ✅
 
-| Agente                 | Rol                             | Trigger                | Modelo     | Costo aprox. |
-| ---------------------- | ------------------------------- | ---------------------- | ---------- | ------------ |
-| **R1: Issue Analyzer** | Analizar impacto y complejidad  | Label `ai-analyze`     | Haiku 4.5  | ~$0.04       |
-| **R2: PR Generator**   | Generar PR completa desde issue | Label `ai-generate-pr` | Sonnet 4.5 | ~$0.30       |
-| **R3: PR Reviewer**    | Code review automático          | PR abierta             | Haiku 4.5  | ~$0.01       |
-| **R4: CI/CD**          | Lint, test, build               | Push/PR                | —          | —            |
-| **R5: Doc Generator**  | Actualizar CHANGELOG            | PR mergeada            | Haiku 4.5  | ~$0.03       |
-| **@claude**            | Handler interactivo             | `@claude` en issues/PRs | Sonnet 4  | variable     |
+| Agente                 | Rol                             | Trigger                 | Modelo     | Costo aprox. |
+| ---------------------- | ------------------------------- | ----------------------- | ---------- | ------------ |
+| **R1: Issue Analyzer** | Analizar impacto y complejidad  | Label `ai-analyze`      | Haiku 4.5  | ~$0.04       |
+| **R2: PR Generator**   | Generar PR completa desde issue | Label `ai-generate-pr`  | Sonnet 4.5 | ~$0.30       |
+| **R3: PR Reviewer**    | Code review automático          | PR abierta              | Haiku 4.5  | ~$0.01       |
+| **R4: CI/CD**          | Lint, test, build               | Push/PR                 | —          | —            |
+| **R5: Doc Generator**  | Actualizar CHANGELOG            | PR mergeada             | Haiku 4.5  | ~$0.03       |
+| **@claude**            | Handler interactivo             | `@claude` en issues/PRs | Sonnet 4   | variable     |
 
 **Pipeline completo validado**: Issue #17 → R1 → R2 (PR #18) → R3 → merge → R5. Total: 28 turns, ~$0.38.
 

--- a/prompts/remote/doc-generator.md
+++ b/prompts/remote/doc-generator.md
@@ -10,15 +10,15 @@ Agente remoto (GitHub Actions + Claude) que actualiza automáticamente el CHANGE
 
 ## Configuración
 
-| Campo | Valor |
-|-------|-------|
-| **Workflow** | `.github/workflows/ai-update-changelog.yml` |
-| **Trigger** | `pull_request.closed` (merged = true) |
-| **Modelo** | `claude-sonnet-4-5-20250929` |
-| **Max turns** | 5 |
-| **Timeout** | 5 minutos |
-| **Permisos** | `contents: write` |
-| **Checkout** | `ref: main` (post-merge) |
+| Campo         | Valor                                       |
+| ------------- | ------------------------------------------- |
+| **Workflow**  | `.github/workflows/ai-update-changelog.yml` |
+| **Trigger**   | `pull_request.closed` (merged = true)       |
+| **Modelo**    | `claude-sonnet-4-5-20250929`                |
+| **Max turns** | 5                                           |
+| **Timeout**   | 5 minutos                                   |
+| **Permisos**  | `contents: write`                           |
+| **Checkout**  | `ref: main` (post-merge)                    |
 
 ## Prompt
 
@@ -34,12 +34,12 @@ El agente recibe la PR mergeada (título, descripción, diff) y acceso al CHANGE
 
 ### Categorías (Keep a Changelog)
 
-| Categoría | Uso |
-|-----------|-----|
-| **Añadido** | Nueva funcionalidad |
-| **Cambiado** | Cambio en funcionalidad existente |
-| **Corregido** | Corrección de errores |
-| **Eliminado** | Funcionalidad eliminada |
+| Categoría     | Uso                               |
+| ------------- | --------------------------------- |
+| **Añadido**   | Nueva funcionalidad               |
+| **Cambiado**  | Cambio en funcionalidad existente |
+| **Corregido** | Corrección de errores             |
+| **Eliminado** | Funcionalidad eliminada           |
 
 ### Formato de Entrada
 
@@ -48,6 +48,7 @@ El agente recibe la PR mergeada (título, descripción, diff) y acceso al CHANGE
 ```
 
 Ejemplos:
+
 - `- Añadir campo clima a la actividad (#42)`
 - `- Corregir cálculo de Normalized Power en archivos GPX (#38)`
 - `- Eliminar endpoint deprecated /api/v1/legacy (#45)`

--- a/prompts/remote/issue-analyzer.md
+++ b/prompts/remote/issue-analyzer.md
@@ -10,14 +10,14 @@ Agente remoto (GitHub Actions + Claude) que analiza issues etiquetadas con `ai-a
 
 ## Configuración
 
-| Campo | Valor |
-|-------|-------|
-| **Workflow** | `.github/workflows/ai-analyze-issue.yml` |
-| **Trigger** | `issues.labeled` → label `ai-analyze` |
-| **Modelo** | `claude-sonnet-4-5-20250929` |
-| **Max turns** | 3 |
-| **Timeout** | 5 minutos |
-| **Permisos** | `contents: read`, `issues: write` |
+| Campo         | Valor                                    |
+| ------------- | ---------------------------------------- |
+| **Workflow**  | `.github/workflows/ai-analyze-issue.yml` |
+| **Trigger**   | `issues.labeled` → label `ai-analyze`    |
+| **Modelo**    | `claude-sonnet-4-5-20250929`             |
+| **Max turns** | 3                                        |
+| **Timeout**   | 5 minutos                                |
+| **Permisos**  | `contents: read`, `issues: write`        |
 
 ## Prompt
 

--- a/prompts/remote/pr-generator.md
+++ b/prompts/remote/pr-generator.md
@@ -10,15 +10,15 @@ Agente remoto (GitHub Actions + Claude Code) que genera automáticamente una PR 
 
 ## Configuración
 
-| Campo | Valor |
-|-------|-------|
-| **Workflow** | `.github/workflows/ai-generate-pr.yml` |
-| **Trigger** | `issues.labeled` → label `ai-generate-pr` |
-| **Modelo** | `claude-sonnet-4-5-20250929` |
-| **Max turns** | 15 |
-| **Timeout** | 15 minutos |
-| **Permisos** | `contents: write`, `pull-requests: write`, `issues: write` |
-| **Setup previo** | pnpm install + Node 22 (antes de Claude) |
+| Campo            | Valor                                                      |
+| ---------------- | ---------------------------------------------------------- |
+| **Workflow**     | `.github/workflows/ai-generate-pr.yml`                     |
+| **Trigger**      | `issues.labeled` → label `ai-generate-pr`                  |
+| **Modelo**       | `claude-sonnet-4-5-20250929`                               |
+| **Max turns**    | 15                                                         |
+| **Timeout**      | 15 minutos                                                 |
+| **Permisos**     | `contents: write`, `pull-requests: write`, `issues: write` |
+| **Setup previo** | pnpm install + Node 22 (antes de Claude)                   |
 
 ## Prompt
 

--- a/prompts/remote/pr-reviewer.md
+++ b/prompts/remote/pr-reviewer.md
@@ -10,15 +10,15 @@ Agente remoto (GitHub Actions + Claude) que revisa automáticamente las PRs abie
 
 ## Configuración
 
-| Campo | Valor |
-|-------|-------|
-| **Workflow** | `.github/workflows/ai-review-pr.yml` |
-| **Trigger** | `pull_request.opened` / `pull_request.synchronize` |
-| **Modelo** | `claude-sonnet-4-5-20250929` |
-| **Max turns** | 3 |
-| **Timeout** | 5 minutos |
-| **Permisos** | `contents: read`, `pull-requests: write` |
-| **Excluye** | PRs de `dependabot[bot]`, `github-actions[bot]` |
+| Campo         | Valor                                              |
+| ------------- | -------------------------------------------------- |
+| **Workflow**  | `.github/workflows/ai-review-pr.yml`               |
+| **Trigger**   | `pull_request.opened` / `pull_request.synchronize` |
+| **Modelo**    | `claude-sonnet-4-5-20250929`                       |
+| **Max turns** | 3                                                  |
+| **Timeout**   | 5 minutos                                          |
+| **Permisos**  | `contents: read`, `pull-requests: write`           |
+| **Excluye**   | PRs de `dependabot[bot]`, `github-actions[bot]`    |
 
 ## Prompt
 
@@ -34,18 +34,21 @@ El agente recibe el diff de la PR y acceso al repositorio completo para contexto
 ### Criterios de Review
 
 #### Calidad del Código
+
 - TypeScript estricto (no `any`, types correctos)
 - Adherencia a convenciones del proyecto
 - Legibilidad y mantenibilidad
 - Complejidad innecesaria o sobre-ingeniería
 
 #### Seguridad
+
 - RLS policies en cambios de DB
 - Validación de inputs con Zod
 - No exposición de secrets o datos sensibles
 - OWASP top 10 (XSS, SQL injection, etc.)
 
 #### Tests
+
 - Cobertura de los cambios
 - Calidad de los tests (no solo cobertura)
 - Tests faltantes sugeridos


### PR DESCRIPTION
Los workflows ci-frontend y ci-backend usaban `pnpm --filter` que bypasea
Turborepo, impidiendo que `shared` se compile antes del typecheck/lint/test.
Cambiar a `turbo run --filter=` respeta `dependsOn: ["^build"]` del turbo.json.

También corrige format:check que era un no-op (los paquetes no tenían ese script)
y formatea los archivos markdown que no pasaban la validación de Prettier.

Closes #19

https://claude.ai/code/session_01B6Wd3wmXBJpZP6hZHKRotE