### PR TITLE
fix: migrar guardado de perfil a Server Action para evitar errores de red

### DIFF
--- a/apps/web/src/app/(app)/profile/actions.ts
+++ b/apps/web/src/app/(app)/profile/actions.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { apiPatch, getServerToken } from "@/lib/api/server";
+import type { OnboardingData } from "shared";
+
+interface SaveProfileResult {
+  success: boolean;
+  error?: string;
+  code?: string;
+}
+
+export async function saveProfile(data: OnboardingData): Promise<SaveProfileResult> {
+  const token = await getServerToken();
+  if (!token) {
+    return { success: false, error: "NO_SESSION", code: "NO_SESSION" };
+  }
+
+  try {
+    await apiPatch("/profile", token, data);
+    revalidatePath("/profile");
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+
+    // Extract HTTP status code from "API NNN: ..." format
+    const statusMatch = message.match(/^API (\d+):/);
+    const status = statusMatch ? parseInt(statusMatch[1]) : 500;
+
+    if (status === 401) {
+      return { success: false, error: "Sesión expirada. Recarga la página.", code: "UNAUTHORIZED" };
+    }
+    if (status >= 400 && status < 500) {
+      return {
+        success: false,
+        error: "Error de validación. Revisa los datos e inténtalo de nuevo.",
+        code: "VALIDATION",
+      };
+    }
+    return {
+      success: false,
+      error: "Error del servidor al guardar. Inténtalo de nuevo.",
+      code: "SERVER_ERROR",
+    };
+  }
+}

--- a/apps/web/src/app/(app)/profile/profile-content.tsx
+++ b/apps/web/src/app/(app)/profile/profile-content.tsx
@@ -11,7 +11,7 @@ import { OnboardingField } from "@/components/onboarding-field";
 import { GoalCard } from "@/components/goal-card";
 import { ZoneTable } from "@/components/zone-table";
 import { ProfileHeader } from "./profile-header";
-import { apiClientPatch } from "@/lib/api/client";
+import { saveProfile } from "./actions";
 
 interface ProfileContentProps {
   profile: {
@@ -84,27 +84,23 @@ export function ProfileContent({ profile }: ProfileContentProps) {
       return;
     }
 
-    try {
-      await apiClientPatch("/profile", {
-        display_name: parsed.data.display_name,
-        age: parsed.data.age,
-        weight_kg: parsed.data.weight_kg,
-        ftp: parsed.data.ftp ?? null,
-        max_hr: parsed.data.max_hr ?? null,
-        rest_hr: parsed.data.rest_hr ?? null,
-        goal: parsed.data.goal,
-      });
+    const result = await saveProfile({
+      display_name: parsed.data.display_name,
+      age: parsed.data.age,
+      weight_kg: parsed.data.weight_kg,
+      ftp: parsed.data.ftp ?? null,
+      max_hr: parsed.data.max_hr ?? null,
+      rest_hr: parsed.data.rest_hr ?? null,
+      goal: parsed.data.goal,
+    });
+
+    if (result.success) {
       setOriginalData({ ...formData });
       router.refresh();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Error al guardar. Inténtalo de nuevo.";
-      if (message.includes("No authenticated session")) {
-        setErrors({ _form: "Sesión expirada. Recarga la página e inténtalo de nuevo." });
-      } else if (message.includes("API 4")) {
-        setErrors({ _form: "Error de validación. Revisa los datos e inténtalo de nuevo." });
-      } else {
-        setErrors({ _form: "Error al guardar. Inténtalo de nuevo." });
-      }
+    } else if (result.code === "NO_SESSION") {
+      setErrors({ _form: "Sesión expirada. Recarga la página e inténtalo de nuevo." });
+    } else {
+      setErrors({ _form: result.error ?? "Error al guardar. Inténtalo de nuevo." });
     }
 
     setIsSaving(false);

--- a/apps/web/src/lib/api/server.ts
+++ b/apps/web/src/lib/api/server.ts
@@ -31,3 +31,25 @@ export async function apiGet<T>(path: string, token: string): Promise<T> {
 
   return res.json() as Promise<T>;
 }
+
+/**
+ * PATCH al API backend desde Server Components / Server Actions.
+ * Recibe el token JWT de Supabase Auth para autenticación.
+ */
+export async function apiPatch<T>(path: string, token: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_URL}/api/v1${path}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "Unknown error");
+    throw new Error(`API ${res.status}: ${text}`);
+  }
+
+  return res.json() as Promise<T>;
+}


### PR DESCRIPTION
El guardado de perfil usaba apiClientPatch (fetch directo desde el
browser al API backend), lo que fallaba cuando el navegador no podía
alcanzar la URL del API (CORS, localhost desde móvil, mixed content).

La carga del perfil funcionaba porque usa un Server Component que hace
la petición desde el servidor Next.js. Ahora el guardado también se
ejecuta en el servidor mediante un Server Action, usando la misma ruta
de comunicación que ya funciona para la carga.

Cambios:
- Nuevo Server Action saveProfile en profile/actions.ts
- Nuevo apiPatch en lib/api/server.ts (server-side PATCH helper)
- Mejor manejo de errores con mensajes específicos por tipo
- Eliminada dependencia de apiClientPatch en profile-content.tsx

https://claude.ai/code/session_01RiroNuD3oqkCQ1m6tnLhxE