### PR TITLE
fix: restringir despliegues a rama main en Vercel, Render y GitHub CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -11,6 +11,7 @@ on:
       - "turbo.json"
       - ".github/workflows/ci-backend.yml"
   pull_request:
+    branches: [main]
     paths:
       - "apps/api/**"
       - "packages/shared/**"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -11,6 +11,7 @@ on:
       - "turbo.json"
       - ".github/workflows/ci-frontend.yml"
   pull_request:
+    branches: [main]
     paths:
       - "apps/web/**"
       - "packages/shared/**"

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,7 @@
 services:
   - type: web
     name: cycling-companion-api
+    branch: main
     rootDir: apps/api
     runtime: node
     plan: standard

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,6 @@
     "apps/web/**/*.tsx": {
       "maxDuration": 30
     }
-  }
+  },
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]"
 }


### PR DESCRIPTION
- Vercel: añadir ignoreCommand para saltar builds en ramas != main
- Render: añadir branch: main al servicio API
- GitHub Actions: limitar pull_request CI a PRs que apunten a main

https://claude.ai/code/session_01GgoE3vLWAzFFWgcufFvcVT